### PR TITLE
Cyclic Constraints Bug

### DIFF
--- a/examples/paper-examples/ring-lights/source.frg
+++ b/examples/paper-examples/ring-lights/source.frg
@@ -42,35 +42,31 @@ option min_tracelength 5
 // We need more than 5 states to find a solution
 option max_tracelength 10 
 
+// option verbose 5
+run {
+    -- well-formedness constraints
+    ring
+    -- start in an initial state
+    init 
 
-run {ring} for exactly 3 Light
+    -- transition predicate: either flip a single light, or we're done
+    always {        
+        -- Do nothing for a solved board. Otherwise, flip a switch
+        {            
+            solved -- guard
+            Lit = Lit' -- action
+        } or {
+            not solved -- guard
+            one l: Light | flip[l] -- action
+        }        
+    }
 
-// // option verbose 5
-// run {
-//     -- well-formedness constraints
-//     ring
-//     -- start in an initial state
-//     init 
+    -- find a trace that leads to a solved state
+    eventually solved
 
-//     -- transition predicate: either flip a single light, or we're done
-//     always {        
-//         -- Do nothing for a solved board. Otherwise, flip a switch
-//         {            
-//             solved -- guard
-//             Lit = Lit' -- action
-//         } or {
-//             not solved -- guard
-//             one l: Light | flip[l] -- action
-//         }        
-//     }
-
-//     -- find a trace that leads to a solved state
-//     eventually solved
-
-//     -- If we wanted, we could exclude some unproductive behavior by adding, e.g.:
-//     -- Loopback can't be to the beginning
-//     --next_state { always { some Lit }}    
+    -- If we wanted, we could exclude some unproductive behavior by adding, e.g.:
+    -- Loopback can't be to the beginning
+    --next_state { always { some Lit }}    
     
-// } 
-// for exactly 3 Light, 5 Lit, 5 Unlit
-
+} 
+for exactly 5 Light, 5 Lit, 5 Unlit

--- a/examples/paper-examples/ring-lights/source.frg
+++ b/examples/paper-examples/ring-lights/source.frg
@@ -42,31 +42,35 @@ option min_tracelength 5
 // We need more than 5 states to find a solution
 option max_tracelength 10 
 
-// option verbose 5
-run {
-    -- well-formedness constraints
-    ring
-    -- start in an initial state
-    init 
 
-    -- transition predicate: either flip a single light, or we're done
-    always {        
-        -- Do nothing for a solved board. Otherwise, flip a switch
-        {            
-            solved -- guard
-            Lit = Lit' -- action
-        } or {
-            not solved -- guard
-            one l: Light | flip[l] -- action
-        }        
-    }
+run {ring} for exactly 3 Light
 
-    -- find a trace that leads to a solved state
-    eventually solved
+// // option verbose 5
+// run {
+//     -- well-formedness constraints
+//     ring
+//     -- start in an initial state
+//     init 
 
-    -- If we wanted, we could exclude some unproductive behavior by adding, e.g.:
-    -- Loopback can't be to the beginning
-    --next_state { always { some Lit }}    
+//     -- transition predicate: either flip a single light, or we're done
+//     always {        
+//         -- Do nothing for a solved board. Otherwise, flip a switch
+//         {            
+//             solved -- guard
+//             Lit = Lit' -- action
+//         } or {
+//             not solved -- guard
+//             one l: Light | flip[l] -- action
+//         }        
+//     }
+
+//     -- find a trace that leads to a solved state
+//     eventually solved
+
+//     -- If we wanted, we could exclude some unproductive behavior by adding, e.g.:
+//     -- Loopback can't be to the beginning
+//     --next_state { always { some Lit }}    
     
-} 
-for exactly 5 Light, 5 Lit, 5 Unlit
+// } 
+// for exactly 3 Light, 5 Lit, 5 Unlit
+

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cope-and-drag",
-  "version": "3.4.8",
+  "version": "3.4.9",
   "description": "A web application for lightweight diagramming for Alloy/Forge.",
   "main": "dist/index.js",
   "keywords": [],

--- a/src/index.ts
+++ b/src/index.ts
@@ -41,7 +41,7 @@ app.use(express.urlencoded({ extended: true, limit: '50mb' }));
 app.use(express.json({ limit: '50mb' }));
 
 // This is a hack. I'm not sure how to encode the version number.
-const version = "3.4.8";
+const version = "3.4.9";
 
 const secretKey = "cope-and-drag-logging-key";
 

--- a/src/layout/layoutinstance.ts
+++ b/src/layout/layoutinstance.ts
@@ -716,9 +716,11 @@ export class LayoutInstance {
                     );
                 }
             }
+
             if(currentLayoutError) {
                 throw new Error(`${currentLayoutError}`);
             }
+            throw new Error(`Failed to find a satisfying layout for cyclic constraints.`);
            
         }
 

--- a/src/layout/layoutinstance.ts
+++ b/src/layout/layoutinstance.ts
@@ -27,8 +27,6 @@ import { WrappedForgeEvaluator } from '../forge-util/evaluatorUtil';
 import { ColorPicker } from './colorpicker';
 import { ConstraintValidator } from './constraint-validator';
 import { SingleValue } from 'forge-expr-evaluator/dist/ForgeExprEvaluator';
-import { Layout } from 'webcola';
-
 const UNIVERSAL_TYPE = "univ";
 
 

--- a/src/layout/layoutinstance.ts
+++ b/src/layout/layoutinstance.ts
@@ -675,7 +675,7 @@ export class LayoutInstance {
 
 
         // First, for each, get the tuples / fragments.
-
+        let layoutNodePaths: LayoutNodePath[] = [];
         let constraintFragments = [];
 
         for (const [index, c] of cyclicConstraints.entries()) {
@@ -701,9 +701,10 @@ export class LayoutInstance {
             let relatedNodeFragments = this.getFragmentsToConstrain(nextNodeMap);
 
 
-            // TODO: Keep the existing fragments, not just their ids for now.
+            // TODO: An optimization: Keep the existing fragments, not just their ids for now.
             // Move the counterclockwise reversal to LATER.
             // AFTER we dedup layoutNodePaths.
+
 
 
             let relatedNodeIds = relatedNodeFragments.map((p) => p.Path.map((node) => node.id));
@@ -720,8 +721,6 @@ export class LayoutInstance {
                     fragmentList: fragment
                 });
             });
-
-
 
         }
 

--- a/src/layout/layoutinstance.ts
+++ b/src/layout/layoutinstance.ts
@@ -689,7 +689,7 @@ export class LayoutInstance {
             let currentLayoutError = "";
             if (fragmentIdx >= constraintFragments.length) {
                 // Base case: All fragments have been processed
-                return [];
+                return layoutConstraints;
             }
 
             let fragment = constraintFragments[fragmentIdx].fragmentList;

--- a/src/layout/layoutinstance.ts
+++ b/src/layout/layoutinstance.ts
@@ -700,6 +700,12 @@ export class LayoutInstance {
 
             let relatedNodeFragments = this.getFragmentsToConstrain(nextNodeMap);
 
+
+            // TODO: Keep the existing fragments, not just their ids for now.
+            // Move the counterclockwise reversal to LATER.
+            // AFTER we dedup layoutNodePaths.
+
+
             let relatedNodeIds = relatedNodeFragments.map((p) => p.Path.map((node) => node.id));
             // Now we have the related node fragments for this constraint.
 
@@ -718,6 +724,9 @@ export class LayoutInstance {
 
 
         }
+
+
+
 
         const minRadius = 100; // Example fixed distance.
 

--- a/src/layout/layoutinstance.ts
+++ b/src/layout/layoutinstance.ts
@@ -727,12 +727,6 @@ export class LayoutInstance {
 
         const finalConstraints: LayoutConstraint[] = backtrackSolveFragments(layoutWithoutCyclicConstraints.constraints, 0);
 
-
-
-
-
-
-
         return finalConstraints;
     }
 


### PR DESCRIPTION
- Naiive fix to the cyclic constraints bug #88 
- This implements VERY dumb backtracking / horn clause search to look for something.


## TODO:

- [] Some optimizations before we check this in (it is quite slow in the worst case). 
- [] E.G. what if some fragments are identical? Or contain the same nodes? (This might need some kind of lexicographic sort on fragment elements when there is a loop)
