### PR TITLE
Add temporal side-by-side visualization

### DIFF
--- a/src/public/css/diagramstyle.css
+++ b/src/public/css/diagramstyle.css
@@ -105,3 +105,13 @@
     stroke-width: 3px; /* Change this to your desired highlight width */
 }
 
+.temporal-diagram {
+    background: #fafafa;
+    padding: 8px;
+    border-radius: 4px;
+}
+
+#diagram-column h4.lead {
+    font-weight: 600;
+}
+

--- a/src/public/js/renderer.js
+++ b/src/public/js/renderer.js
@@ -106,7 +106,7 @@ function getContainingGroups(groups, node) {
 
 
 
-function setupLayout(d3, nodes, edges, constraints, groups, width, height) {
+function setupLayout(d3, nodes, edges, constraints, groups, width, height, svgId = "svg") {
 
 
     let edgeRouteIdx = 0;
@@ -121,8 +121,11 @@ function setupLayout(d3, nodes, edges, constraints, groups, width, height) {
         .scaleExtent([0.5, 5]) // Set the zoom scale limits
         .on("zoom", zoomed);
 
+    const svgTop = d3.select(`#${svgId}`).call(zoom);
+    const zoomTarget = svgTop.select(".zoomable");
+
     function zoomed() {
-        d3.select(".zoomable").attr("transform", d3.event.transform);
+        zoomTarget.attr("transform", d3.event.transform);
     }
 
     function getNodeIndex(n) {
@@ -136,8 +139,7 @@ function setupLayout(d3, nodes, edges, constraints, groups, width, height) {
         node.name = node.id;
     });
 
-    var svg_top = d3.select("#svg").call(zoom);
-    var svg = d3.select(".zoomable");
+    var svg = svgTop.select(".zoomable");
 
     var colaLayout = cola.d3adaptor(d3)
         .convergenceThreshold(1e-3)
@@ -442,13 +444,13 @@ function setupLayout(d3, nodes, edges, constraints, groups, width, height) {
             // Update label positions after routing edges
             linkGroups.select("text.linklabel")
                 .attr("x", function (d) {
-                    const pathElement = document.querySelector(`path[data-link-id="${d.id}"]`);
+                    const pathElement = svg.node().querySelector(`path[data-link-id="${d.id}"]`);
                     const pathLength = pathElement.getTotalLength();
                     const midpoint = pathElement.getPointAtLength(pathLength / 2);
                     return midpoint.x;
                 })
                 .attr("y", function (d) {
-                    const pathElement = document.querySelector(`path[data-link-id="${d.id}"]`);
+                    const pathElement = svg.node().querySelector(`path[data-link-id="${d.id}"]`);
                     const pathLength = pathElement.getTotalLength();
                     const midpoint = pathElement.getPointAtLength(pathLength / 2);
                     return midpoint.y;
@@ -458,7 +460,7 @@ function setupLayout(d3, nodes, edges, constraints, groups, width, height) {
                     const currentLabel = this;
                     const overlapsWith = [];
 
-                    d3.selectAll("text.linklabel").each(function () {
+                    svg.selectAll("text.linklabel").each(function () {
                         if (this !== currentLabel && isOverlapping(currentLabel, this)) {
                             overlapsWith.push(this);
                         }
@@ -482,12 +484,12 @@ function setupLayout(d3, nodes, edges, constraints, groups, width, height) {
             ].join(' ');
 
 
-            const topSvg = d3.select("#svg");
+            const topSvg = d3.select(`#${svgId}`);
             topSvg.attr('viewBox', viewBox);
             /*************************************/
 
             function highlightRelation(relName) {
-                d3.selectAll(".link")
+                svg.selectAll(".link")
                     .filter(link => link.relName === relName)
                     .classed("highlighted", true);
             }
@@ -784,11 +786,11 @@ function setupLayout(d3, nodes, edges, constraints, groups, width, height) {
 
         linkGroups.select("text.linklabel")
             .attr("x", d => {
-                const pathElement = document.querySelector(`path[data-link-id="${d.id}"]`);
+                const pathElement = svg.node().querySelector(`path[data-link-id="${d.id}"]`);
                 return calculateNewPosition(d.x, pathElement, 'x');
             })
             .attr("y", d => {
-                const pathElement = document.querySelector(`path[data-link-id="${d.id}"]`);
+                const pathElement = svg.node().querySelector(`path[data-link-id="${d.id}"]`);
                 return calculateNewPosition(d.y, pathElement, 'y');
             })
             .raise();

--- a/src/views/diagram.ejs
+++ b/src/views/diagram.ejs
@@ -26,16 +26,32 @@
     <script>
         window.addEventListener('load', function () {
 
-            var width = <%- width %>, height = <%- height %>;
-            var nodes = <%- JSON.stringify(colaNodes) %>;
-            var edges = <%- JSON.stringify(colaEdges) %>;
-            var constraints = <%- JSON.stringify(colaConstraints) %>;
-            var groups = <%- JSON.stringify(colaGroups) %>;
+            const primary = {
+                width: <%- width %>,
+                height: <%- height %>,
+                nodes: <%- JSON.stringify(colaNodes) %>,
+                edges: <%- JSON.stringify(colaEdges) %>,
+                constraints: <%- JSON.stringify(colaConstraints) %>,
+                groups: <%- JSON.stringify(colaGroups) %>,
+            };
 
-            if (width && height && nodes && edges && constraints && groups) {
-                setupLayout(d3, nodes, edges, constraints, groups, width, height);
+            const neighbor = {
+                width: <%- temporalNeighbor ? temporalNeighbor.width : 0 %>,
+                height: <%- temporalNeighbor ? temporalNeighbor.height : 0 %>,
+                nodes: <%- temporalNeighbor ? JSON.stringify(temporalNeighbor.colaNodes) : '[]' %>,
+                edges: <%- temporalNeighbor ? JSON.stringify(temporalNeighbor.colaEdges) : '[]' %>,
+                constraints: <%- temporalNeighbor ? JSON.stringify(temporalNeighbor.colaConstraints) : '[]' %>,
+                groups: <%- temporalNeighbor ? JSON.stringify(temporalNeighbor.colaGroups) : '[]' %>,
+            };
+
+            if (primary.width && primary.height && primary.nodes && primary.edges && primary.constraints && primary.groups) {
+                setupLayout(d3, primary.nodes, primary.edges, primary.constraints, primary.groups, primary.width, primary.height, "svg-primary");
             } else {
                 console.error('Missing required data for layout');
+            }
+
+            if (neighbor.width && neighbor.height && neighbor.nodes && neighbor.nodes.length > 0) {
+                setupLayout(d3, neighbor.nodes, neighbor.edges, neighbor.constraints, neighbor.groups, neighbor.width, neighbor.height, "svg-next");
             }
         });
     </script>
@@ -87,7 +103,7 @@
 
         <div class="row">
             <%- include('relationTable') %>
-            <%- include('diagramsvg') %>
+            <%- include('temporalsidebyside') %>
 
             <%- include('controls') %>
         </div>

--- a/src/views/relationTable.ejs
+++ b/src/views/relationTable.ejs
@@ -120,8 +120,12 @@
         </div>
         <br>
         <script>
-            function downloadHighResPNG(scaleFactor = 3) {
-                const svg = document.getElementById("svg");
+            function downloadHighResPNG(scaleFactor = 3, svgElementId = "svg-primary") {
+                const svg = document.getElementById(svgElementId);
+                if (!svg) {
+                    console.warn(`No SVG found with id ${svgElementId} to download.`);
+                    return;
+                }
                 const serializer = new XMLSerializer();
                 let source = serializer.serializeToString(svg);
 

--- a/src/views/temporalsidebyside.ejs
+++ b/src/views/temporalsidebyside.ejs
@@ -1,0 +1,42 @@
+<div id="diagram-column" class="col">
+    <div class="row">
+        <div class="col-lg-6 col-md-12 mb-3">
+            <div class="d-flex justify-content-between align-items-center mb-1">
+                <h4 class="lead mb-0">State <%= instanceNumber %></h4>
+                <span class="badge badge-primary">current</span>
+            </div>
+            <div class="temporal-diagram">
+                <svg id="svg-primary" width="<%- width %>" height="<%- height %>" class="svg-border">
+                    <defs>
+                        <marker id="end-arrow" markerWidth="15" markerHeight="10" refX="12" refY="5" orient="auto">
+                            <polygon points="0 0, 15 5, 0 10" />
+                        </marker>
+                    </defs>
+                    <g class="zoomable"></g>
+                </svg>
+            </div>
+        </div>
+        <% if (temporalNeighbor && temporalNeighbor.colaNodes && temporalNeighbor.colaNodes.length > 0) { %>
+            <div class="col-lg-6 col-md-12 mb-3">
+                <div class="d-flex justify-content-between align-items-center mb-1">
+                    <h4 class="lead mb-0">State <%= temporalNeighbor.instanceNumber %></h4>
+                    <% if (temporalNeighbor.isLoopBack) { %>
+                        <span class="badge badge-warning">loop</span>
+                    <% } else { %>
+                        <span class="badge badge-secondary">next</span>
+                    <% } %>
+                </div>
+                <div class="temporal-diagram">
+                    <svg id="svg-next" width="<%- temporalNeighbor.width %>" height="<%- temporalNeighbor.height %>" class="svg-border">
+                        <defs>
+                            <marker id="end-arrow" markerWidth="15" markerHeight="10" refX="12" refY="5" orient="auto">
+                                <polygon points="0 0, 15 5, 0 10" />
+                            </marker>
+                        </defs>
+                        <g class="zoomable"></g>
+                    </svg>
+                </div>
+            </div>
+        <% } %>
+    </div>
+</div>


### PR DESCRIPTION
## Summary
- generate and pass neighboring temporal layouts alongside the requested state
- render current and next temporal states side-by-side with updated templates, renderer scoping, and styling
- keep download/export utilities working with the primary diagram and ensure example routes include neighbor data

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69260fc2f0c8832ca421b0046dd677b3)