### PR TITLE
Reframe docs landing and add The Views page

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -21,6 +21,7 @@ export default defineConfig({
           text: 'Guide',
           items: [
             { text: 'Getting Started', link: '/guide/getting-started' },
+            { text: 'The Views', link: '/guide/views' },
             { text: 'Edit Mode (experimental)', link: '/guide/edit-mode' },
           ],
         },

--- a/docs/guide/views.md
+++ b/docs/guide/views.md
@@ -1,0 +1,41 @@
+# The Views
+
+CnD exposes four views over an instance, selected from the buttons in the top nav: **Graph**, **Table**, **Script**, and **Edit**. Only Graph and Edit are driven by the CnD spec; Table and Script are independent surfaces.
+
+## Graph view
+
+The default view, and the one you'll spend most of your time in. It renders the current Alloy/Forge instance as a constraint-solved diagram, using the active CnD spec to decide layout and styling.
+
+The **Layout drawer** (right-hand side) holds the CnD editor. Projections and temporal-trace navigation also surface here — see [Projections](../cnd/projections) and [Temporal Mode](../cnd/temporal).
+
+### Code View vs Structured Builder
+
+Inside the Layout drawer, the CnD editor has two modes, toggled at the top of the drawer:
+
+- **Code View** — a raw YAML editor over `constraints:` and `directives:` blocks. This is the canonical surface, and the recommended one for anyone (human or agent) already familiar with the CnD language. The full grammar is in the [YAML Specification](../cnd/yaml-spec).
+- **Structured Builder** — a form-based editor where constraints and directives are added, removed, and reordered through UI controls instead of typed YAML. Useful for learning the vocabulary by exploration, and for readers who aren't comfortable editing YAML directly.
+
+The two views share a single underlying spec: switching modes regenerates the other representation from the current one, and undo/redo works across the toggle. The Structured Builder covers constraints and directives; `projections:` and `temporal:` blocks are not yet surfaced in the form UI, but are preserved through round-trips so they won't be lost by switching.
+
+Two actions sit above the editor:
+
+- **Apply Layout** — commits the current spec and re-renders the diagram.
+- **Upload `.cnd`** — loads a spec from a local file.
+
+> **For agents writing `.cnd` specs:** prefer Code View and write against the grammar in [YAML Specification](../cnd/yaml-spec). The Structured Builder is a pedagogical surface, not a canonical one.
+
+## Table view
+
+A tabular browse of the instance: sigs and their fields rendered as HTML tables. The Table view does **not** consult the CnD spec — it's a plain data browser for the raw solver output, useful for cross-referencing what the diagram shows against what the instance actually contains.
+
+## Script view
+
+A split pane: a Monaco JavaScript editor on one side, a live rendering stage on the other. You write imperative visualization code against the raw instance, with D3 and the SpyTial visualization APIs available. Run with Ctrl+Enter.
+
+The Script view is **independent of the CnD spec**. Reach for it when CnD's declarative vocabulary isn't enough and you need imperative, bespoke control over the rendering — custom charts, non-graph layouts, algorithmic visualizations. For standard relational-diagram work, Graph view is the right tool.
+
+## Edit view
+
+Experimental. An interactive editor for building or modifying instances by hand — add atoms, connect fields, modify relations — and then exporting the result as a Forge/Alloy `inst` block you can paste back into a model file. The Edit view respects the active CnD spec while you edit, so constraints and directives apply during construction.
+
+→ See [Edit Mode (experimental)](./edit-mode) for the full walkthrough.

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,12 +17,12 @@ hero:
       link: https://github.com/sidprasad/copeanddrag
 
 features:
-  - title: Spatial refinement, not brute layout
-    details: Describe where things should be relative to each other. Let the solver do the arranging.
-  - title: Sterling-native
-    details: Fork of the Sterling visualizer for Alloy and Forge, with CnD replacing DAGRE as the layout engine.
-  - title: Language-first
-    details: A small DSL for selectors, constraints, and layout directives — readable, composable, and spec-driven.
-  - title: Projections, traces, and editing
-    details: Slice instances by sig, navigate temporal traces with a sequence policy, or edit instances in-browser and export as inst.
+  - title: Constraints, separate from directives
+    details: Spatial constraints describe where atoms go. Visual directives describe how they look. The two compose independently.
+  - title: For Alloy and Forge instances
+    details: CnD reads solver output and lets you specify layouts declaratively over sigs, atoms, and fields — no pixel coordinates.
+  - title: Grounded in how diagrams communicate
+    details: The constraint and directive vocabulary is drawn from cognitive-science principles and corpus studies on spatial reasoning in diagrams.
+  - title: Runs inside Sterling
+    details: A fork of the Sterling visualizer for Alloy and Forge, with CnD replacing DAGRE as the layout engine.
 ---


### PR DESCRIPTION
## Summary

- **Landing page cards rewritten** to mirror the thesis proposal's framing of CnD — constraints separated from directives, Alloy/Forge instance scope, cognitive-science grounding, Sterling fork — instead of generic marketing taglines. Hero, tagline, and action buttons are unchanged.
- **New `docs/guide/views.md`** with a concise overview of the four top-nav views (Graph, Table, Script, Edit) and the **Code View vs Structured Builder** toggle inside the Graph view's Layout drawer. Aimed at users and LLM agents writing `.cnd` specs, who previously had no docs for these surfaces.
- **Sidebar nav** updated to surface the new page: `Getting Started → The Views → Edit Mode (experimental)`.

Docs-only; no JS/TS code changes.

## Test plan

- [x] `vitepress build` completes without errors or broken links
- [x] Dev server renders the four new feature cards on the landing page, hero unchanged
- [x] Guide sidebar shows Getting Started → The Views → Edit Mode (experimental)
- [x] `/guide/views` renders with H2 sections for Graph, Table, Script, and Edit view, plus a Code View vs Structured Builder subsection under Graph
- [x] Internal link from the Edit section to `./edit-mode` resolves (200)
- [x] YAML Specification cross-link from the Code View description resolves

🤖 Generated with [Claude Code](https://claude.com/claude-code)