### PR TITLE
Add feature tests driven by the mock provider

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -65,12 +65,13 @@ module.exports = {
     '^.+\\.jsx?$': [
       //'babel-jest',
        'ts-jest',
-      {        
+      {
         useESM: true
-        // https://babeljs.io/docs/en/babel-core/#options        
+        // https://babeljs.io/docs/en/babel-core/#options
       },
     ],
-  },  
+    '\\.xml$': '<rootDir>/util/jest-xml-transformer.cjs',
+  },
   // From ts-jest guide on supporting paths mapping
   // note we replaced the moduleNameMapper given in the startup guide above
   //modulePaths: ['<rootDir>/packages', '<rootDir>/node_modules'],

--- a/packages/alloy-instance/test/xml.test.ts
+++ b/packages/alloy-instance/test/xml.test.ts
@@ -1,0 +1,57 @@
+/** @jest-environment jsdom */
+import { describe, expect, it } from '@jest/globals';
+import { getInstanceAtoms, getInstanceTypes, parseAlloyXML } from '../index';
+import rcXml from '../../../demos/rc/rc-datum.xml';
+
+describe('parseAlloyXML on the rc fixture', () => {
+  it('produces a 12-instance trace', () => {
+    const datum = parseAlloyXML(rcXml);
+    expect(datum.instances).toHaveLength(12);
+  });
+
+  it('reads top-level Alloy attributes from the first instance', () => {
+    const datum = parseAlloyXML(rcXml);
+    expect(datum.bitwidth).toBe(4);
+    expect(datum.command).toBe('temporary-name_rc_1');
+    expect(datum.loopBack).toBe(10);
+  });
+
+  it('exposes the river-crossing signatures in the first instance', () => {
+    const datum = parseAlloyXML(rcXml);
+    const ids = getInstanceTypes(datum.instances[0]).map((t) => t.id);
+    expect(ids).toEqual(
+      expect.arrayContaining(['GWBoat', 'GWAnimal', 'Goat', 'Wolf', 'Position', 'Near', 'Far'])
+    );
+  });
+
+  it('exposes the expected atoms in the first instance', () => {
+    const datum = parseAlloyXML(rcXml);
+    const ids = getInstanceAtoms(datum.instances[0]).map((a) => a.id);
+    expect(ids).toEqual(
+      expect.arrayContaining([
+        'GWBoat0',
+        'Goat0', 'Goat1', 'Goat2',
+        'Wolf0', 'Wolf1', 'Wolf2',
+        'Near0', 'Far0'
+      ])
+    );
+  });
+
+  it('throws when there is no <instance> element', () => {
+    expect(() => parseAlloyXML('<alloy></alloy>')).toThrow(/No Alloy instance/);
+  });
+
+  it('parses deterministically (same input → structurally equal trace shape)', () => {
+    const a = parseAlloyXML(rcXml);
+    const b = parseAlloyXML(rcXml);
+    expect(a.instances.length).toBe(b.instances.length);
+    expect(a.bitwidth).toBe(b.bitwidth);
+    expect(a.command).toBe(b.command);
+    expect(a.loopBack).toBe(b.loopBack);
+    for (let i = 0; i < a.instances.length; i++) {
+      expect(getInstanceAtoms(a.instances[i]).map((x) => x.id).sort()).toEqual(
+        getInstanceAtoms(b.instances[i]).map((x) => x.id).sort()
+      );
+    }
+  });
+});

--- a/packages/sterling-connection/src/__tests__/mockIntegration.test.ts
+++ b/packages/sterling-connection/src/__tests__/mockIntegration.test.ts
@@ -1,0 +1,106 @@
+/** @jest-environment jsdom */
+import { describe, expect, it } from '@jest/globals';
+import { configureStore } from '@reduxjs/toolkit';
+import dataReducer from '../../../sterling/src/state/data/dataSlice';
+import evaluatorReducer from '../../../sterling/src/state/evaluator/evaluatorSlice';
+import providerReducer from '../../../sterling/src/state/provider/providerSlice';
+import {
+  buttonClicked,
+  connectSterling,
+  evalRequested,
+  metaRequested
+} from '../actions';
+import { sterlingConnectionMiddleware } from '../middleware';
+
+// Drives the mock provider through the real middleware + slices to prove the
+// "graph loads" path end-to-end. The mock fires its replies from setTimeout(0)
+// callbacks, so each round-trip needs a couple of flushes to settle.
+const flush = () => new Promise<void>((r) => setTimeout(r, 0));
+const settle = async () => {
+  await flush();
+  await flush();
+};
+
+function makeStore() {
+  return configureStore({
+    reducer: {
+      provider: providerReducer,
+      data: dataReducer,
+      evaluator: evaluatorReducer
+    },
+    middleware: (getDefault) =>
+      getDefault({
+        // The state stores non-serializable parsed instances (DOM-derived
+        // AlloyDatum) and the mock middleware uses non-serializable actions
+        // for the WebSocket reference; disable both checks for the test store.
+        serializableCheck: false,
+        immutableCheck: false
+      }).concat(sterlingConnectionMiddleware())
+  });
+}
+
+describe('mock provider end-to-end', () => {
+  it('marks the store connected after dispatching connectSterling("mock")', async () => {
+    const store = makeStore();
+    store.dispatch(connectSterling('mock'));
+    await settle();
+    expect(store.getState().provider.connected).toBe(true);
+  });
+
+  it('populates provider metadata after metaRequested', async () => {
+    const store = makeStore();
+    store.dispatch(connectSterling('mock'));
+    await settle();
+    store.dispatch(metaRequested());
+    await settle();
+    const { provider } = store.getState();
+    expect(provider.providerName).toBe('Mock');
+    expect(provider.providerGenerators).toEqual(expect.arrayContaining(['rc']));
+  });
+
+  it('lands a fully-parsed 12-instance trace in the data slice when the rc generator is clicked', async () => {
+    const store = makeStore();
+    store.dispatch(connectSterling('mock'));
+    await settle();
+    store.dispatch(
+      buttonClicked({
+        id: undefined,
+        onClick: 'run',
+        context: { generatorName: 'rc' }
+      })
+    );
+    await settle();
+    const { data } = store.getState();
+    expect(data.datumIds).toHaveLength(1);
+    expect(data.active).not.toBeNull();
+    const datum = data.datumById[data.active!];
+    expect(datum.format).toBe('alloy');
+    // Punchline: the rc XML flowed through the real Alloy parser and the
+    // 12-frame trace is intact in state. Regressions in parseAlloyXML,
+    // parseJoin, onMessage, or dataExtraReducers all surface here.
+    expect(datum.parsed.instances).toHaveLength(12);
+  });
+
+  it('round-trips an eval expression through the evaluator slice', async () => {
+    const store = makeStore();
+    store.dispatch(connectSterling('mock'));
+    await settle();
+    store.dispatch(
+      buttonClicked({
+        id: undefined,
+        onClick: 'run',
+        context: { generatorName: 'rc' }
+      })
+    );
+    await settle();
+    const datumId = store.getState().data.active!;
+    store.dispatch(
+      evalRequested({ id: 'e1', datumId, expression: '1+1' })
+    );
+    await settle();
+    const expr = store.getState().evaluator.expressionsById['e1'];
+    expect(expr).toBeDefined();
+    expect(expr.expression).toBe('1+1');
+    expect(expr.result).toBe('(mock) 1+1');
+  });
+});

--- a/packages/sterling-connection/src/mock/__tests__/MockWebSocketLike.test.ts
+++ b/packages/sterling-connection/src/mock/__tests__/MockWebSocketLike.test.ts
@@ -1,0 +1,99 @@
+/** @jest-environment jsdom */
+import { describe, expect, it, jest } from '@jest/globals';
+import { FIXTURES } from '../fixtures';
+import { MockWebSocketLike } from '../MockWebSocketLike';
+
+const flush = () => new Promise<void>((r) => setTimeout(r, 0));
+
+describe('MockWebSocketLike', () => {
+  it('fires onopen async and transitions readyState CONNECTING → OPEN', async () => {
+    const ws = new MockWebSocketLike();
+    expect(ws.readyState).toBe(WebSocket.CONNECTING);
+    const onopen = jest.fn();
+    ws.onopen = onopen;
+    await flush();
+    expect(onopen).toHaveBeenCalledTimes(1);
+    expect(ws.readyState).toBe(WebSocket.OPEN);
+  });
+
+  it('responds to ping with pong', async () => {
+    const ws = new MockWebSocketLike();
+    const onmessage = jest.fn<(ev: { data: string }) => void>();
+    ws.onmessage = onmessage;
+    await flush();
+    ws.send('ping');
+    await flush();
+    expect(onmessage).toHaveBeenCalledTimes(1);
+    expect(onmessage.mock.calls[0][0]).toEqual({ data: 'pong' });
+  });
+
+  it('responds to a meta request with provider metadata advertising the rc generator', async () => {
+    const ws = new MockWebSocketLike();
+    const onmessage = jest.fn<(ev: { data: string }) => void>();
+    ws.onmessage = onmessage;
+    await flush();
+    ws.send(JSON.stringify({ type: 'meta' }));
+    await flush();
+    const reply = JSON.parse(onmessage.mock.calls[0][0].data);
+    expect(reply.type).toBe('meta');
+    expect(reply.version).toBe(1);
+    expect(reply.payload.evaluator).toBe('mock');
+    expect(reply.payload.generators).toEqual(expect.arrayContaining(['rc']));
+  });
+
+  it('responds to a click on the rc generator with the rc fixture XML', async () => {
+    const ws = new MockWebSocketLike();
+    const onmessage = jest.fn<(ev: { data: string }) => void>();
+    ws.onmessage = onmessage;
+    await flush();
+    ws.send(
+      JSON.stringify({
+        type: 'click',
+        payload: { id: undefined, onClick: 'run', context: { generatorName: 'rc' } }
+      })
+    );
+    await flush();
+    const reply = JSON.parse(onmessage.mock.calls[0][0].data);
+    expect(reply.type).toBe('data');
+    expect(reply.payload.enter).toHaveLength(1);
+    const entry = reply.payload.enter[0];
+    expect(entry.format).toBe('alloy');
+    expect(entry.generatorName).toBe('rc');
+    expect(entry.data).toBe(FIXTURES.rc.xml);
+  });
+
+  it('drops sends issued before onopen has fired', async () => {
+    const ws = new MockWebSocketLike();
+    const onmessage = jest.fn<(ev: { data: string }) => void>();
+    ws.onmessage = onmessage;
+    ws.send(JSON.stringify({ type: 'meta' }));
+    await flush();
+    expect(onmessage).not.toHaveBeenCalled();
+  });
+
+  it('closes async and ignores subsequent sends', async () => {
+    const ws = new MockWebSocketLike();
+    const onclose = jest.fn();
+    const onmessage = jest.fn<(ev: { data: string }) => void>();
+    ws.onclose = onclose;
+    ws.onmessage = onmessage;
+    await flush();
+    ws.close();
+    await flush();
+    expect(ws.readyState).toBe(WebSocket.CLOSED);
+    expect(onclose).toHaveBeenCalledTimes(1);
+    ws.send(JSON.stringify({ type: 'meta' }));
+    await flush();
+    expect(onmessage).not.toHaveBeenCalled();
+  });
+
+  it('silently ignores invalid JSON', async () => {
+    const ws = new MockWebSocketLike();
+    const onmessage = jest.fn<(ev: { data: string }) => void>();
+    ws.onmessage = onmessage;
+    await flush();
+    expect(() => ws.send('not json')).not.toThrow();
+    await flush();
+    expect(onmessage).not.toHaveBeenCalled();
+  });
+});

--- a/packages/sterling/src/utils/__tests__/cndPreParser.test.ts
+++ b/packages/sterling/src/utils/__tests__/cndPreParser.test.ts
@@ -1,0 +1,119 @@
+import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
+import * as yaml from 'js-yaml';
+import { parseCndFile } from '../cndPreParser';
+
+describe('parseCndFile', () => {
+  let warnSpy: ReturnType<typeof jest.spyOn>;
+
+  beforeEach(() => {
+    warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
+  describe('input shape handling', () => {
+    it('returns defaults for empty input', () => {
+      expect(parseCndFile('')).toEqual({
+        projections: [],
+        sequence: { policy: 'ignore_history' },
+        layoutYaml: ''
+      });
+    });
+
+    it('returns defaults for whitespace-only input', () => {
+      expect(parseCndFile('   \n\t  ')).toEqual({
+        projections: [],
+        sequence: { policy: 'ignore_history' },
+        layoutYaml: ''
+      });
+    });
+
+    it('passes scalar (non-object) YAML through as raw layoutYaml', () => {
+      const r = parseCndFile('hello');
+      expect(r.projections).toEqual([]);
+      expect(r.sequence.policy).toBe('ignore_history');
+      expect(r.layoutYaml).toBe('hello');
+    });
+  });
+
+  describe('projections extraction', () => {
+    it('extracts an array of projection objects', () => {
+      const r = parseCndFile(
+        'projections:\n  - sig: State\n    orderBy: next\n  - sig: Time\n'
+      );
+      expect(r.projections).toEqual([
+        { type: 'State', orderBy: 'next' },
+        { type: 'Time' }
+      ]);
+    });
+
+    it('accepts `type:` and `sig:` interchangeably and trims whitespace', () => {
+      const r = parseCndFile(
+        'projections:\n  - type: "  Foo  "\n  - sig: Bar\n'
+      );
+      expect(r.projections).toEqual([{ type: 'Foo' }, { type: 'Bar' }]);
+    });
+
+    it('handles singular `projection:` as an object', () => {
+      const r = parseCndFile('projection:\n  sig: State\n');
+      expect(r.projections).toEqual([{ type: 'State' }]);
+    });
+
+    it('skips entries with missing or empty type/sig and warns', () => {
+      const r = parseCndFile(
+        'projections:\n  - sig: State\n  - sig: ""\n  - {}\n'
+      );
+      expect(r.projections).toEqual([{ type: 'State' }]);
+      expect(warnSpy).toHaveBeenCalled();
+    });
+  });
+
+  describe('temporal / sequence policy', () => {
+    it('parses the object form `temporal: { policy: stability }`', () => {
+      const r = parseCndFile('temporal:\n  policy: stability\n');
+      expect(r.sequence.policy).toBe('stability');
+    });
+
+    it('parses the bare-string shorthand `temporal: change_emphasis`', () => {
+      const r = parseCndFile('temporal: change_emphasis');
+      expect(r.sequence.policy).toBe('change_emphasis');
+    });
+
+    it('accepts `sequence:` as an alias for `temporal:`', () => {
+      const r = parseCndFile('sequence:\n  policy: random_positioning\n');
+      expect(r.sequence.policy).toBe('random_positioning');
+    });
+
+    it('falls back to ignore_history for an unknown policy and warns', () => {
+      const r = parseCndFile('temporal:\n  policy: nonsense\n');
+      expect(r.sequence.policy).toBe('ignore_history');
+      expect(warnSpy).toHaveBeenCalled();
+    });
+  });
+
+  describe('layoutYaml rebuild', () => {
+    it('keeps only constraints + directives and strips the CND-only blocks', () => {
+      const r = parseCndFile(
+        'projections:\n  - sig: State\n' +
+          'temporal: stability\n' +
+          'constraints:\n  - orientation:\n      selector: friend\n      directions: [right]\n' +
+          'directives:\n  - flag: hideDisconnectedBuiltIns\n'
+      );
+      const reparsed = yaml.load(r.layoutYaml) as Record<string, unknown>;
+      expect(reparsed).toEqual({
+        constraints: [
+          { orientation: { selector: 'friend', directions: ['right'] } }
+        ],
+        directives: [{ flag: 'hideDisconnectedBuiltIns' }]
+      });
+      expect(reparsed.projections).toBeUndefined();
+      expect(reparsed.temporal).toBeUndefined();
+    });
+
+    it('returns empty layoutYaml when no constraints/directives exist', () => {
+      const r = parseCndFile('temporal: stability');
+      expect(r.layoutYaml).toBe('');
+    });
+  });
+});

--- a/util/jest-xml-transformer.cjs
+++ b/util/jest-xml-transformer.cjs
@@ -1,0 +1,7 @@
+// Mirrors webpack's `asset/source` for `.xml` imports under jest, so
+// `import rcXml from '...rc-datum.xml'` returns the file contents as a string.
+module.exports = {
+  process(src) {
+    return { code: 'module.exports = ' + JSON.stringify(src) + ';' };
+  }
+};


### PR DESCRIPTION
## Summary
- Use the mock provider from #108 to drive regression coverage on the surfaces most likely to silently break: Alloy XML parsing, the CnD YAML preprocessor, the mock's WebSocket contract, and the connect→parse→state pipeline end-to-end.
- Four new test files (30 tests) plus a tiny `.xml` jest transformer.

## What's covered

**`packages/alloy-instance/test/xml.test.ts`** (6 tests) — pins `parseAlloyXML` against the rc fixture. Asserts 12-instance trace, `bitwidth=4`, `command='temporary-name_rc_1'`, `loopBack=10`, expected sigs (`Goat`, `Wolf`, `GWBoat`, `Position`, `Near`, `Far`, `GWAnimal`), expected atoms, throw-on-empty, deterministic parse. Catches alloy-instance regressions directly.

**`packages/sterling/src/utils/__tests__/cndPreParser.test.ts`** (13 tests) — covers the YAML preprocessor that defines this fork (CnD's projection/sequence extraction). Previously zero coverage. Cases: empty/whitespace/scalar input, `projections:` array vs singular `projection:`, `type`/`sig` aliasing, `temporal`/`sequence` keys, bare-string and object policy forms, invalid-policy fallback, layoutYaml rebuild that strips CnD-only blocks.

**`packages/sterling-connection/src/mock/__tests__/MockWebSocketLike.test.ts`** (7 tests) — protocol contract: async open lifecycle, `ping→pong`, `meta` advertises `rc` generator, `click` returns the rc XML, sends pre-open are dropped, async close, invalid JSON ignored.

**`packages/sterling-connection/src/__tests__/mockIntegration.test.ts`** (4 tests) — the "graph loads" path. Real Redux store + real `sterlingConnectionMiddleware` + `MockWebSocketLike` + real `parseAlloyDatum`. After clicking the rc generator: `data.datumById[active].parsed.instances.length === 12`. After dispatching `evalRequested`: `evaluator.expressionsById['e1'].result === '(mock) 1+1'`. If `parseAlloyXML`, `parseJoin`, `onMessage`, or `dataExtraReducers` regresses, this fails.

## Foundation

- `util/jest-xml-transformer.cjs` — 5-line transformer that mirrors webpack's `asset/source` so `import rcXml from '...rc-datum.xml'` works under jest.
- `jest.config.cjs` — wires the transformer in via the existing `transform` map.

No new dependencies; `@jest/globals` and `jest-environment-jsdom` are already devDependencies.

## Out of scope (deferred)

React component rendering, alloy-graph layout assertions, trace-stepping via UI hooks, additional fixtures. The first three would require real DOM scaffolding and a meaningful UI test setup; calling them out so the next pass knows where to pick up.

## CI

The existing [.github/workflows/ci.yml](.github/workflows/ci.yml) runs `yarn test` on every PR and push to main (line 18). Jest's default test discovery picks up all four new files — `yarn test --listTests` confirms locally. No CI changes needed.

## Test plan
- [x] `yarn test` from the repo root passes — 15 suites, 68 tests green
- [x] `yarn test --listTests` includes all four new files
- [x] `yarn test mockIntegration` passes in isolation (proves the rc XML imports cleanly through the new transformer and the trace is intact in state)
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)