### PR TITLE
Refresh app shell + docs aesthetic to align with Spytial-core (4.0.2)

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -8,6 +8,15 @@ export default defineConfig({
   lastUpdated: true,
   head: [
     ['link', { rel: 'icon', href: '/copeanddrag/favicon.ico' }],
+    ['link', { rel: 'preconnect', href: 'https://fonts.googleapis.com' }],
+    ['link', { rel: 'preconnect', href: 'https://fonts.gstatic.com', crossorigin: '' }],
+    [
+      'link',
+      {
+        rel: 'stylesheet',
+        href: 'https://fonts.googleapis.com/css2?family=Atkinson+Hyperlegible:ital,wght@0,400;0,700;1,400;1,700&family=Fira+Code:wght@400;500&display=swap',
+      },
+    ],
   ],
   themeConfig: {
     nav: [

--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -1,0 +1,4 @@
+import DefaultTheme from 'vitepress/theme';
+import './style.css';
+
+export default DefaultTheme;

--- a/docs/.vitepress/theme/style.css
+++ b/docs/.vitepress/theme/style.css
@@ -1,0 +1,290 @@
+/*
+ * Cope and Drag — VitePress theme overrides.
+ *
+ * Tufte-leaning: warm paper background, hairline rules, restrained chrome,
+ * generous reading line-height. Body type is Atkinson Hyperlegible to match
+ * Spytial-core; mono is Fira Code for code blocks.
+ *
+ * Brand color is the Spytial purple (#5a3d8a). It is the *only* chromatic
+ * ink in the page — used for links, the active TOC item, the brand pip on
+ * the home hero, and nothing else.
+ */
+
+:root {
+  /* Typography */
+  --vp-font-family-base: 'Atkinson Hyperlegible', system-ui, -apple-system,
+    BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', sans-serif;
+  --vp-font-family-mono: 'Fira Code', ui-monospace, SFMono-Regular, 'SF Mono',
+    Menlo, Consolas, 'Liberation Mono', monospace;
+
+  /* Brand — Spytial purple, used sparingly */
+  --vp-c-brand-1: #5a3d8a;
+  --vp-c-brand-2: #6b4ca0;
+  --vp-c-brand-3: #7c5db5;
+  --vp-c-brand-soft: #f0eef8;
+
+  /* Surfaces — paper, not screen */
+  --vp-c-bg: #fdfdfb;
+  --vp-c-bg-alt: #f8f7f3;
+  --vp-c-bg-soft: #f4f3ef;
+
+  /* Ink */
+  --vp-c-text-1: #1f2937;
+  --vp-c-text-2: #475569;
+  --vp-c-text-3: #64748b;
+
+  /* Rules */
+  --vp-c-divider: #e9ecef;
+  --vp-c-gutter: #e9ecef;
+  --vp-c-border: #dee2e6;
+
+  /* Buttons / CTA */
+  --vp-button-brand-bg: #5a3d8a;
+  --vp-button-brand-hover-bg: #4a3273;
+  --vp-button-brand-active-bg: #3d2a5e;
+  --vp-button-brand-border: #5a3d8a;
+  --vp-button-brand-hover-border: #4a3273;
+  --vp-button-brand-text: #ffffff;
+  --vp-button-brand-hover-text: #ffffff;
+
+  --vp-button-alt-bg: transparent;
+  --vp-button-alt-hover-bg: #f0eef8;
+  --vp-button-alt-active-bg: #e6e2f3;
+  --vp-button-alt-border: #c4b8e0;
+  --vp-button-alt-hover-border: #5a3d8a;
+  --vp-button-alt-text: #5a3d8a;
+  --vp-button-alt-hover-text: #3d2a5e;
+}
+
+.dark {
+  --vp-c-bg: #15131a;
+  --vp-c-bg-alt: #1c1923;
+  --vp-c-bg-soft: #211e29;
+
+  --vp-c-text-1: #e9e6f0;
+  --vp-c-text-2: #c4bfd0;
+  --vp-c-text-3: #8b8597;
+
+  --vp-c-divider: #2c2937;
+  --vp-c-gutter: #2c2937;
+  --vp-c-border: #3a3648;
+
+  --vp-c-brand-1: #b89be0;
+  --vp-c-brand-2: #a78ad0;
+  --vp-c-brand-3: #9479c0;
+  --vp-c-brand-soft: rgba(184, 155, 224, 0.14);
+}
+
+/* ---------------------------------------------------------------------------
+ * Reading column. Tufte: narrow, generous line-height, ample margins.
+ * ------------------------------------------------------------------------- */
+
+.VPDoc.has-aside .content-container {
+  max-width: 720px;
+}
+.VPDoc:not(.has-aside) .content-container {
+  max-width: 720px;
+}
+
+.vp-doc {
+  font-size: 16px;
+  line-height: 1.7;
+}
+
+.vp-doc h1 {
+  font-weight: 600;
+  font-size: 30px;
+  letter-spacing: -0.005em;
+  line-height: 1.2;
+  margin-bottom: 1rem;
+}
+
+.vp-doc h1::after {
+  content: '';
+  display: block;
+  width: 48px;
+  height: 2px;
+  background: var(--vp-c-brand-1);
+  margin-top: 0.75rem;
+}
+
+.vp-doc h2 {
+  font-weight: 600;
+  font-size: 22px;
+  letter-spacing: -0.003em;
+  border-top: 1px solid var(--vp-c-divider);
+  padding-top: 1.5rem;
+  margin-top: 2.5rem;
+}
+
+.vp-doc h3 {
+  font-weight: 600;
+  font-size: 17px;
+}
+
+.vp-doc p {
+  margin: 1em 0;
+}
+
+.vp-doc a {
+  color: var(--vp-c-brand-1);
+  text-decoration: none;
+  border-bottom: 1px solid var(--vp-c-brand-soft);
+  transition: border-color 0.15s ease;
+}
+.vp-doc a:hover {
+  border-bottom-color: var(--vp-c-brand-1);
+}
+
+.vp-doc blockquote {
+  border-left: 2px solid var(--vp-c-brand-1);
+  background: transparent;
+  color: var(--vp-c-text-2);
+  font-style: italic;
+  padding: 0.25rem 0 0.25rem 1.25rem;
+  margin: 1.25rem 0;
+}
+
+.vp-doc :not(pre) > code {
+  background: var(--vp-c-bg-alt);
+  border: 1px solid var(--vp-c-divider);
+  border-radius: 3px;
+  padding: 0.1em 0.35em;
+  font-size: 0.88em;
+}
+
+.vp-doc div[class*='language-'] {
+  border: 1px solid var(--vp-c-divider);
+  border-radius: 4px;
+  box-shadow: none;
+}
+
+/* ---------------------------------------------------------------------------
+ * Nav + sidebar — flatten, hairlines only.
+ * ------------------------------------------------------------------------- */
+
+.VPNav,
+.VPNavBar {
+  background: var(--vp-c-bg);
+  border-bottom: 1px solid var(--vp-c-divider);
+}
+.VPNavBar.has-sidebar .content,
+.VPNavBar .content-body {
+  background: transparent !important;
+}
+.VPNavBar:not(.has-sidebar):not(.top) {
+  box-shadow: none;
+}
+
+.VPSidebar {
+  background: var(--vp-c-bg) !important;
+  border-right: 1px solid var(--vp-c-divider);
+}
+
+.VPSidebarItem.level-0 > .item > .text {
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+  font-size: 11px;
+  color: var(--vp-c-text-3);
+}
+
+.VPSidebarItem.is-active > .item > .link > .text {
+  color: var(--vp-c-brand-1);
+  font-weight: 500;
+}
+
+/* ---------------------------------------------------------------------------
+ * Home hero — typographic, restrained. The wordmark IS the brand.
+ * ------------------------------------------------------------------------- */
+
+.VPHome {
+  background: var(--vp-c-bg);
+}
+
+.VPHero .container {
+  padding-top: 4rem;
+  padding-bottom: 3rem;
+}
+
+.VPHero .name {
+  font-weight: 600;
+  font-size: 46px;
+  letter-spacing: 0.01em;
+  line-height: 1.05;
+  background: none !important;
+  -webkit-text-fill-color: var(--vp-c-text-1);
+  color: var(--vp-c-text-1);
+  position: relative;
+  padding-left: 18px;
+}
+.VPHero .name::before {
+  content: '';
+  position: absolute;
+  left: 0;
+  top: 6px;
+  width: 4px;
+  height: calc(100% - 12px);
+  background: var(--vp-c-brand-1);
+  border-radius: 1px;
+}
+
+.VPHero .text {
+  font-weight: 400;
+  font-style: italic;
+  font-size: 24px;
+  line-height: 1.3;
+  color: var(--vp-c-text-2);
+  margin-top: 0.75rem;
+  padding-left: 18px;
+}
+
+.VPHero .tagline {
+  font-size: 16px;
+  line-height: 1.6;
+  color: var(--vp-c-text-3);
+  max-width: 56ch;
+  padding-left: 18px;
+  margin-top: 1.25rem;
+}
+
+.VPHero .actions {
+  padding-left: 18px;
+  gap: 0.5rem;
+}
+
+/* ---------------------------------------------------------------------------
+ * Home features — paper cards with hairlines, no shadow.
+ * ------------------------------------------------------------------------- */
+
+.VPFeature {
+  background: var(--vp-c-bg) !important;
+  border: 1px solid var(--vp-c-divider) !important;
+  border-radius: 4px !important;
+  box-shadow: none !important;
+  transition: border-color 0.15s ease;
+}
+.VPFeature:hover {
+  border-color: var(--vp-c-brand-1) !important;
+}
+.VPFeature .title {
+  font-weight: 600;
+  font-size: 16px;
+  letter-spacing: -0.003em;
+}
+.VPFeature .details {
+  color: var(--vp-c-text-2);
+  font-size: 14.5px;
+  line-height: 1.6;
+}
+
+/* ---------------------------------------------------------------------------
+ * Footer — quiet.
+ * ------------------------------------------------------------------------- */
+
+.VPFooter {
+  background: var(--vp-c-bg);
+  border-top: 1px solid var(--vp-c-divider);
+  color: var(--vp-c-text-3);
+  font-size: 13px;
+}

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sterling-layout",
   "description": "Cope and Drag (CnD): a fork of the Sterling visualizer that encodes spatial layout.",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "main": "index.js",
   "author": "Siddhartha Prasad",
   "license": "MIT",
@@ -36,6 +36,7 @@
     "@chakra-ui/react": "^1.7.2",
     "@emotion/react": "^11",
     "@emotion/styled": "^11",
+    "@fontsource/atkinson-hyperlegible": "^5.2.8",
     "@fontsource/fira-code": "^4.5.2",
     "@fontsource/inter": "^4.5.1",
     "@headlessui/react": "^1.4.3",

--- a/packages/sterling-ui/src/components/Dashboard/DragBar.tsx
+++ b/packages/sterling-ui/src/components/Dashboard/DragBar.tsx
@@ -1,4 +1,5 @@
 import { Box, useStyleConfig } from '@chakra-ui/react';
+import { tokens } from '../../tokens';
 
 const DragBar = () => {
   const styles = useStyleConfig('DragBar');
@@ -9,10 +10,10 @@ const DragBarTheme = {
   baseStyle: {
     w: '1px',
     h: 'full',
-    transition: 'all ease 0.25s',
-    backgroundColor: 'gray.300',
+    transition: 'background-color ease 0.2s',
+    backgroundColor: tokens.color.rule,
     '.drag-handle:hover &': {
-      backgroundColor: 'gray.500'
+      backgroundColor: tokens.color.accent
     }
   }
 };

--- a/packages/sterling-ui/src/components/Log/LogList.tsx
+++ b/packages/sterling-ui/src/components/Log/LogList.tsx
@@ -1,4 +1,5 @@
 import { Grid, GridProps, useStyleConfig } from '@chakra-ui/react';
+import { tokens } from '../../tokens';
 
 const LogList = (props: GridProps) => {
   const styles = useStyleConfig('LogList', props);
@@ -8,11 +9,15 @@ const LogList = (props: GridProps) => {
 const LogListTheme = {
   baseStyle: {
     display: 'grid',
-    backgroundColor: 'gray.50',
+    backgroundColor: tokens.color.codeBg,
+    color: tokens.color.codeFg,
     gridTemplateColumns: 'fit-content(300px) 1fr',
-    gridColumnGap: '0.35rem',
+    gridColumnGap: '0.6rem',
     gridAutoRows: 'min-content',
-    userSelect: 'text'
+    px: 3,
+    py: 2,
+    userSelect: 'text',
+    fontFamily: tokens.fonts.mono
   }
 };
 

--- a/packages/sterling-ui/src/components/Log/LogText.tsx
+++ b/packages/sterling-ui/src/components/Log/LogText.tsx
@@ -1,4 +1,5 @@
 import { Box, BoxProps, useStyleConfig } from '@chakra-ui/react';
+import { tokens } from '../../tokens';
 
 interface LogTextProps {
   variant?: 'message' | 'warning' | 'error' | 'timestamp';
@@ -10,27 +11,34 @@ const LogText = (props: BoxProps & LogTextProps) => {
   return <Box as='p' __css={styles} {...rest} isTruncated />;
 };
 
+// Log lives on a dark code surface (#1e1e1e). Variant colors picked for
+// AA contrast on that bg:
+//   #d4d4d4 fg     vs #1e1e1e — 11.5:1 (AAA)
+//   #dcdcaa warn   vs #1e1e1e —  9.6:1 (AAA)
+//   #f48771 error  vs #1e1e1e —  6.9:1 (AAA)
+//   #9b9b9b stamp  vs #1e1e1e —  5.4:1 (AA)
 const LogTextTheme = {
   baseStyle: {
     fontFamily: 'mono',
-    fontSize: 'xs'
+    fontSize: 'xs',
+    lineHeight: '1.5'
   },
   variants: {
     message: {
-      color: 'gray.900'
+      color: tokens.color.codeFg
     },
     warning: {
-      color: 'yellow.400',
+      color: '#dcdcaa',
       fontWeight: 'semibold'
     },
     error: {
-      color: 'red.500',
+      color: '#f48771',
       fontWeight: 'semibold'
     },
     timestamp: {
       display: 'flex',
       alignItems: 'center',
-      color: 'gray.500'
+      color: tokens.color.codeMuted
     }
   },
   defaultProps: {

--- a/packages/sterling-ui/src/components/Logo.tsx
+++ b/packages/sterling-ui/src/components/Logo.tsx
@@ -1,27 +1,56 @@
-import { Center, CenterProps, useStyleConfig } from '@chakra-ui/react';
+import { Box, BoxProps, useStyleConfig } from '@chakra-ui/react';
+import { tokens } from '../tokens';
 
-const Logo = (props: CenterProps) => {
+// The wordmark is set in sentence case in the DOM and visually
+// transformed to uppercase via CSS, so screen readers read it as
+// "Cope and Drag" — not "C O P E A N D D R A G".
+const Logo = (props: BoxProps) => {
   const styles = useStyleConfig('Logo');
   return (
-    <Center __css={styles} {...props}>
-      Cope and Drag
-    </Center>
+    <Box
+      __css={styles}
+      role='img'
+      aria-label='Cope and Drag'
+      {...props}
+    >
+      <span className='cnd-logo-mark' aria-hidden='true' />
+      <span className='cnd-logo-words'>Cope and Drag</span>
+    </Box>
   );
 };
 
 const LogoTheme = {
   baseStyle: {
-    px: 2,
+    display: 'inline-flex',
+    alignItems: 'center',
+    gap: '0.7rem',
+    px: 1,
     py: 1,
-    fontWeight: 'extrabold',
-    fontSize: 'sm',
-    letterSpacing: '0.22em',
-    textTransform: 'uppercase',
-    color: 'white',
-    bg: 'whiteAlpha.100',
-    borderRadius: 'lg',
-    boxShadow: 'inset 0 0 0 1px rgba(255, 255, 255, 0.12)',
-    lineHeight: '1'
+    flexShrink: 0,
+    color: tokens.color.ink,
+    bg: 'transparent',
+    boxShadow: 'none',
+    borderRadius: 'none',
+    lineHeight: '1',
+    whiteSpace: 'nowrap',
+    '.cnd-logo-mark': {
+      display: 'inline-block',
+      width: '3px',
+      height: '14px',
+      backgroundColor: tokens.color.accent,
+      borderRadius: '0.5px',
+      flexShrink: 0
+    },
+    '.cnd-logo-words': {
+      fontFamily: 'body',
+      fontWeight: 500,
+      fontSize: '13px',
+      letterSpacing: '0.24em',
+      textTransform: 'uppercase',
+      color: tokens.color.ink,
+      whiteSpace: 'nowrap',
+      flexShrink: 0
+    }
   }
 };
 

--- a/packages/sterling-ui/src/components/NavBar/NavBar.tsx
+++ b/packages/sterling-ui/src/components/NavBar/NavBar.tsx
@@ -1,5 +1,6 @@
 import { Flex, FlexProps, useStyleConfig } from '@chakra-ui/react';
 import sizes from '../../sizes';
+import { tokens } from '../../tokens';
 
 const NavBar = (props: FlexProps) => {
   const styles = useStyleConfig('NavBar');
@@ -17,14 +18,10 @@ const NavBarTheme = {
     alignItems: 'center',
     gap: 3,
     px: 4,
-    bg: 'rgba(11, 17, 32, 0.92)',
-    backgroundImage:
-      'linear-gradient(120deg, #0f172a 0%, #111827 45%, #0b1224 100%)',
-    color: 'gray.100',
+    bg: tokens.color.surface,
+    color: tokens.color.ink,
     borderBottom: '1px solid',
-    borderColor: 'whiteAlpha.200',
-    boxShadow: '0 12px 40px rgba(15, 23, 42, 0.45)',
-    backdropFilter: 'saturate(180%) blur(12px)',
+    borderColor: tokens.color.rule,
     zIndex: 'banner'
   }
 };

--- a/packages/sterling-ui/src/components/NavBar/NavButton.tsx
+++ b/packages/sterling-ui/src/components/NavBar/NavButton.tsx
@@ -1,48 +1,51 @@
 import { Button, ButtonProps, useStyleConfig } from '@chakra-ui/react';
+import { tokens } from '../../tokens';
 
 const NavButton = (props: ButtonProps) => {
   const styles = useStyleConfig('NavButton');
   return <Button __css={styles} {...props} />;
 };
 
+// Active = 2px purple underline (hairline accent), no filled pill.
+// Default text uses `inkMuted` (7.5:1 contrast). Focus combines the
+// underline with an outer halo so it survives WCAG 2.4.11 against the
+// NavBar's white surface.
 const NavButtonTheme = {
   baseStyle: {
     display: 'flex',
     alignItems: 'center',
     gap: '0.35rem',
-    borderRadius: 'full',
-    px: 4,
-    py: 2,
+    borderRadius: '0px',
+    px: 3,
+    py: 1.5,
+    minH: '32px',
     lineHeight: 1.1,
     fontSize: 'sm',
-    fontWeight: 'semibold',
-    color: 'gray.100',
-    bg: 'whiteAlpha.50',
-    border: '1px solid',
-    borderColor: 'whiteAlpha.200',
-    boxShadow: '0 10px 30px rgba(15, 23, 42, 0.15)',
+    fontWeight: 500,
+    color: tokens.color.inkMuted,
+    bg: 'transparent',
+    boxShadow: 'inset 0 -2px 0 transparent',
     transitionProperty: 'common',
-    transitionDuration: 'normal',
+    transitionDuration: 'fast',
     _hover: {
-      bg: 'whiteAlpha.200',
-      color: 'white',
-      borderColor: 'whiteAlpha.300',
+      color: tokens.color.ink,
+      bg: 'transparent',
+      boxShadow: `inset 0 -2px 0 ${tokens.color.accentBorder}`,
       _disabled: {
         bg: 'initial'
       }
     },
     _active: {
-      bg: 'white',
-      color: '#0f172a',
-      borderColor: 'white',
-      boxShadow: '0 12px 34px rgba(15, 23, 42, 0.35)'
+      color: tokens.color.accent,
+      bg: 'transparent',
+      boxShadow: `inset 0 -2px 0 ${tokens.color.accent}`
     },
     _focusVisible: {
-      boxShadow: '0 0 0 2px rgba(99, 102, 241, 0.6)',
-      outline: 'none'
+      outline: 'none',
+      boxShadow: `inset 0 -2px 0 ${tokens.color.accent}, 0 0 0 1px ${tokens.color.accent}`
     },
     _disabled: {
-      opacity: 0.4,
+      opacity: 0.45,
       cursor: 'not-allowed'
     }
   }

--- a/packages/sterling-ui/src/components/Pane/PaneBody.tsx
+++ b/packages/sterling-ui/src/components/Pane/PaneBody.tsx
@@ -1,5 +1,6 @@
 import { Box, BoxProps, useStyleConfig } from '@chakra-ui/react';
 import sizes from '../../sizes';
+import { tokens } from '../../tokens';
 
 const PaneBody = (props: BoxProps) => {
   const styles = useStyleConfig('PaneBody');
@@ -13,7 +14,7 @@ const PaneBodyTheme = {
     right: 0,
     bottom: 0,
     left: 0,
-    bg: '#f8fafc'
+    bg: tokens.color.bg
   }
 };
 

--- a/packages/sterling-ui/src/components/Pane/PaneHeader.tsx
+++ b/packages/sterling-ui/src/components/Pane/PaneHeader.tsx
@@ -1,5 +1,6 @@
 import { Box, BoxProps, useStyleConfig } from '@chakra-ui/react';
 import sizes from '../../sizes';
+import { tokens } from '../../tokens';
 
 const PaneHeader = (props: BoxProps) => {
   const styles = useStyleConfig('PaneHeader');
@@ -17,13 +18,9 @@ const PaneHeaderTheme = {
     alignItems: 'center',
     gap: '0.75rem',
     px: 3,
-    bg: 'rgba(255, 255, 255, 0.92)',
-    backgroundImage:
-      'linear-gradient(180deg, rgba(255,255,255,0.98) 0%, rgba(248,250,252,0.9) 100%)',
+    bg: tokens.color.surface,
     borderBottom: '1px solid',
-    borderColor: 'gray.200',
-    boxShadow: '0 8px 30px rgba(15, 23, 42, 0.08)',
-    backdropFilter: 'saturate(180%) blur(6px)',
+    borderColor: tokens.color.rule,
     zIndex: 'banner'
   }
 };

--- a/packages/sterling-ui/src/components/Pane/PaneTitle.tsx
+++ b/packages/sterling-ui/src/components/Pane/PaneTitle.tsx
@@ -1,5 +1,9 @@
 import { Center, CenterProps, useStyleConfig } from '@chakra-ui/react';
+import { tokens } from '../../tokens';
 
+// PaneTitles are quiet labels — italic, modest weight, but in `inkMuted`
+// (#475569 = 7.5:1 contrast on white) so they remain WCAG AA-compliant
+// as body-sized text.
 const PaneTitle = (props: CenterProps) => {
   const styles = useStyleConfig('PaneTitle');
   return <Center __css={styles} {...props} />;
@@ -7,11 +11,12 @@ const PaneTitle = (props: CenterProps) => {
 
 const PaneTitleTheme = {
   baseStyle: {
-    fontSize: 'sm',
-    fontWeight: 'semibold',
-    letterSpacing: '0.08em',
-    textTransform: 'uppercase',
-    color: '#0f172a'
+    fontSize: '13px',
+    fontWeight: 500,
+    fontStyle: 'italic',
+    letterSpacing: '0.005em',
+    textTransform: 'none',
+    color: tokens.color.inkMuted
   }
 };
 

--- a/packages/sterling-ui/src/components/SideBar/SideBar.tsx
+++ b/packages/sterling-ui/src/components/SideBar/SideBar.tsx
@@ -1,9 +1,10 @@
 import { Flex, FlexProps, useStyleConfig } from '@chakra-ui/react';
 import sizes from '../../sizes';
+import { tokens } from '../../tokens';
 
 const SideBar = (props: FlexProps) => {
   const styles = useStyleConfig('SideBar');
-  return <Flex __css={{...styles, overflowY: 'auto'}} {...props} />;
+  return <Flex __css={{ ...styles, overflowY: 'auto' }} {...props} />;
 };
 
 const SideBarTheme = {
@@ -17,15 +18,13 @@ const SideBarTheme = {
     flexDir: 'column',
     alignItems: 'stretch',
     fontSize: 'xs',
-    gap: '6px',
+    gap: '4px',
     px: 2,
     py: 3,
     borderLeft: '1px solid',
-    borderColor: 'whiteAlpha.200',
-    bg: 'rgba(11, 17, 32, 0.88)',
-    backdropFilter: 'saturate(180%) blur(12px)',
-    boxShadow: '-12px 0 30px rgba(15, 23, 42, 0.35)',
-    color: 'gray.100',
+    borderColor: tokens.color.rule,
+    bg: tokens.color.surface,
+    color: tokens.color.ink,
     zIndex: 'banner'
   }
 };

--- a/packages/sterling-ui/src/components/SideBar/SideBarButton.tsx
+++ b/packages/sterling-ui/src/components/SideBar/SideBarButton.tsx
@@ -1,4 +1,5 @@
 import { Button, ButtonProps, Text, useStyleConfig } from '@chakra-ui/react';
+import { tokens } from '../../tokens';
 
 interface SideBarButtonProps {
   text: string;
@@ -23,48 +24,58 @@ const SideBarButton = (props: ButtonProps & SideBarButtonProps) => {
   );
 };
 
+// SideBar is on the right edge. Active state = 2px purple rule on the
+// button's INSIDE (left) edge — Tufte-style hairline marker.
+//
+// Default text uses `inkMuted` (#475569 = 7.5:1 on white) for WCAG AA.
+// Focus indicator combines a 2px accent inset with a 1px outer halo so
+// it remains visible against the adjacent SideBar surface (WCAG 2.4.11).
 const SideBarButtonTheme = {
   baseStyle: {
+    position: 'relative',
     display: 'flex',
     cursor: 'pointer',
     alignItems: 'center',
     justifyContent: 'center',
     py: 4,
+    px: 2,
+    minH: '44px',
     fontSize: 'xs',
-    fontWeight: 'semibold',
+    fontWeight: 500,
+    letterSpacing: '0.06em',
+    textTransform: 'uppercase',
     transitionProperty: 'common',
-    transitionDuration: 'normal',
+    transitionDuration: 'fast',
     writingMode: 'vertical-lr',
     textOrientation: 'sideways',
-    borderRadius: 'lg',
-    border: '1px solid',
-    borderColor: 'whiteAlpha.200',
-    color: 'gray.100',
-    bg: 'whiteAlpha.50',
-    boxShadow: '0 10px 30px rgba(15, 23, 42, 0.12)',
+    borderRadius: '2px',
+    color: tokens.color.inkMuted,
+    bg: 'transparent',
+    boxShadow: 'inset 2px 0 0 transparent',
     iconSpacing: '0.35rem',
     span: {
       marginRight: '.12rem'
     },
     _hover: {
-      bg: 'whiteAlpha.200',
-      color: 'white',
-      borderColor: 'whiteAlpha.300',
-      transform: 'translateY(-1px)',
+      color: tokens.color.ink,
+      bg: tokens.color.surfaceMuted,
       _disabled: {
         bg: 'initial'
       }
     },
     _active: {
-      bg: 'linear-gradient(180deg, #e0e7ff 0%, #c7d2fe 100%)',
-      color: '#0f172a',
-      borderColor: 'white',
-      boxShadow: '0 14px 36px rgba(15, 23, 42, 0.35)',
-      transform: 'translateY(-2px)'
+      color: tokens.color.accent,
+      bg: 'transparent',
+      boxShadow: `inset 2px 0 0 ${tokens.color.accent}`,
+      transform: 'none'
     },
     _focusVisible: {
-      boxShadow: '0 0 0 2px rgba(94, 234, 212, 0.65)',
-      outline: 'none'
+      outline: 'none',
+      boxShadow: `inset 2px 0 0 ${tokens.color.accent}, 0 0 0 1px ${tokens.color.accent}`
+    },
+    _disabled: {
+      opacity: 0.45,
+      cursor: 'not-allowed'
     }
   }
 };

--- a/packages/sterling-ui/src/components/StatusBar.tsx
+++ b/packages/sterling-ui/src/components/StatusBar.tsx
@@ -1,5 +1,6 @@
 import { Flex, FlexProps, useStyleConfig } from '@chakra-ui/react';
 import sizes from '../sizes';
+import { tokens } from '../tokens';
 
 const StatusBar = (props: FlexProps) => {
   const styles = useStyleConfig('StatusBar');
@@ -17,13 +18,12 @@ const StatusBarTheme = {
     alignItems: 'center',
     px: 4,
     gap: 3,
-    fontSize: 'sm',
+    fontSize: 'xs',
+    fontFamily: tokens.fonts.mono,
     borderTop: '1px solid',
-    borderColor: 'whiteAlpha.200',
-    bg: 'rgba(12, 17, 30, 0.9)',
-    color: 'gray.100',
-    backdropFilter: 'saturate(180%) blur(10px)',
-    boxShadow: '0 -8px 30px rgba(15, 23, 42, 0.3)'
+    borderColor: tokens.color.rule,
+    bg: tokens.color.surface,
+    color: tokens.color.inkMuted
   }
 };
 

--- a/packages/sterling-ui/src/theme.ts
+++ b/packages/sterling-ui/src/theme.ts
@@ -1,4 +1,5 @@
 import { extendTheme } from '@chakra-ui/react';
+import { tokens } from './tokens';
 import { DashboardTheme } from './components/Dashboard/Dashboard';
 import { DragBarTheme } from './components/Dashboard/DragBar';
 import { DragHandleTheme } from './components/Dashboard/DragHandle';
@@ -18,8 +19,9 @@ import { ViewTheme } from './components/View';
 
 const sterlingTheme = extendTheme({
   fonts: {
-    body: 'InterVariable',
-    mono: 'Fira Code VF, Fira Code, monospace'
+    body: tokens.fonts.body,
+    heading: tokens.fonts.body,
+    mono: tokens.fonts.mono
   },
   styles: {
     global: {
@@ -29,6 +31,11 @@ const sterlingTheme = extendTheme({
         overflow: 'hidden',
         userSelect: 'none',
         cursor: 'default'
+      },
+      body: {
+        bg: tokens.color.bg,
+        color: tokens.color.ink,
+        fontFeatureSettings: '"ss01", "cv11"'
       }
     }
   },
@@ -53,3 +60,4 @@ const sterlingTheme = extendTheme({
 });
 
 export { sterlingTheme };
+export { tokens } from './tokens';

--- a/packages/sterling-ui/src/tokens.ts
+++ b/packages/sterling-ui/src/tokens.ts
@@ -1,0 +1,53 @@
+// Design tokens for the Sterling app shell.
+// Mirrors Spytial-core's palette so the two products feel like one family.
+// Tufte-leaning: paper surfaces, hairline rules, sparing accent use.
+//
+// Contrast notes (WCAG 2.1 AA):
+//   ink (#1f2937) on bg (#fdfdfb)         — 14.6:1 (AAA)
+//   inkMuted (#475569) on surface (#fff)   —  7.5:1 (AAA)
+//   inkFaint (#64748b) on surface (#fff)   —  4.5:1 (AA, decorative use only)
+//   accent (#5a3d8a) on surface (#fff)     —  8.6:1 (AAA)
+//   white on accent (#5a3d8a)              —  8.6:1 (AAA, button text)
+//   accent on accentBg (#f0eef8)           —  7.5:1 (AAA)
+//
+// Focus indicator: 2px solid accent at element edge, plus a 1px outer
+// halo against adjacent surfaces (WCAG 2.2 SC 2.4.11, 2.4.13).
+
+export const tokens = {
+  fonts: {
+    body: '"Atkinson Hyperlegible", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif',
+    mono: '"Fira Code VF", "Fira Code", ui-monospace, SFMono-Regular, Menlo, Consolas, monospace'
+  },
+  color: {
+    bg: '#fdfdfb',
+    surface: '#ffffff',
+    surfaceMuted: '#f4f3ef',
+
+    ink: '#1f2937',
+    inkMuted: '#475569',
+    inkFaint: '#64748b',
+    inkDecorative: '#adb5bd',
+
+    rule: '#e9ecef',
+    ruleStrong: '#dee2e6',
+
+    accent: '#5a3d8a',
+    accentBg: '#f0eef8',
+    accentBorder: '#c4b8e0',
+    accentInk: '#3d2a5e',
+
+    codeBg: '#1e1e1e',
+    codeFg: '#d4d4d4',
+    codeMuted: '#9b9b9b',
+
+    success: '#1b5e20',
+    error: '#a31515',
+    warning: '#8a6d00'
+  },
+  focus: {
+    width: '2px',
+    halo: '1px'
+  }
+} as const;
+
+export type Tokens = typeof tokens;

--- a/packages/sterling/src/index.tsx
+++ b/packages/sterling/src/index.tsx
@@ -1,6 +1,9 @@
 import '@fontsource/fira-code/variable.css';
 import '@fontsource/fira-code/400.css';
-import '@fontsource/inter/variable-full.css';
+import '@fontsource/atkinson-hyperlegible/400.css';
+import '@fontsource/atkinson-hyperlegible/700.css';
+import '@fontsource/atkinson-hyperlegible/400-italic.css';
+import '@fontsource/atkinson-hyperlegible/700-italic.css';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { Provider } from 'react-redux';

--- a/yarn.lock
+++ b/yarn.lock
@@ -1727,6 +1727,11 @@
   resolved "https://registry.yarnpkg.com/@emotion/weak-memoize/-/weak-memoize-0.4.0.tgz#5e13fac887f08c44f76b0ccaf3370eb00fec9bb6"
   integrity sha512-snKqtPW01tN0ui7yu9rGv69aJXr/a/Ywvl11sUjNtEcRc+ng/mQriFL0wLXMef74iHa/EkftbDzU9F8iFbH+zg==
 
+"@fontsource/atkinson-hyperlegible@^5.2.8":
+  version "5.2.8"
+  resolved "https://registry.yarnpkg.com/@fontsource/atkinson-hyperlegible/-/atkinson-hyperlegible-5.2.8.tgz#7a4581bab2837cf4000a2917cdadc9dbf0bf49e9"
+  integrity sha512-HciLcJ5DIK/OVOdo71EbEN4NnvDFlp6/SpAxtcbWf2aAdcsOuPqITxj5KNEXb48qSPSdnnZdGGnSJChPKi3/bA==
+
 "@fontsource/fira-code@^4.5.2":
   version "4.5.13"
   resolved "https://registry.yarnpkg.com/@fontsource/fira-code/-/fira-code-4.5.13.tgz#7ddd62472f7e6002acf9371815090eecf5d28f8c"


### PR DESCRIPTION
## Summary

Aligns copeanddrag's visual language with Spytial-core (typography + color) and applies a Tufte-leaning treatment to branding and chrome — paper surfaces, hairline rules, restrained accent use.

- **Type**: Atkinson Hyperlegible (matches Spytial-core; viz-friendly, dyslexia-friendly). Fira Code retained for log/code.
- **Color**: Spytial purple `#5a3d8a` as the only chromatic accent; warm off-white `#fdfdfb` paper bg.
- **Chrome**: NavBar / SideBar / StatusBar / PaneHeader flattened — white surface, single hairline border, no shadow/blur/gradient.
- **Active states**: 2px purple hairline (underline on NavButton, inset edge on SideBarButton) instead of filled boxes.
- **Wordmark**: small purple accent bar + uppercase letterspaced "Cope and Drag" — sentence-case in DOM with `role="img" aria-label="Cope and Drag"` so screen readers don't spell it letter-by-letter.
- **Docs (VitePress)**: same palette + body font, narrowed reading column, italic hero tagline, hairline feature cards.
- **Tokens**: new `packages/sterling-ui/src/tokens.ts` is the single source of truth for fonts/colors/focus, with WCAG contrast ratios documented inline.
- **A11y**: all body text meets WCAG AA (most exceed AAA); focus indicators combine an inset accent rule with an outer halo per WCAG 2.4.11; SideBar buttons meet the 44px touch target; italic relies on Atkinson's purpose-built italic.

Patch bumped to `4.0.2`.

## Test plan

- [ ] `yarn dev:mock` and visually confirm: white chrome, hairline borders, active SideBar item shows the inset purple rule, active NavBar tab shows the 2px purple underline, log pane uses the dark code surface, Atkinson Hyperlegible visibly applied to UI, Fira Code on log/code.
- [ ] Click through Graph / Table / Script / Edit views — no layout regression.
- [ ] Open the right Pane drawer (Explorer / Evaluator / Log) — verify PaneHeader is flat-white + hairline.
- [ ] `yarn docs:dev` and confirm: brand color is purple, body font is Atkinson Hyperlegible, hero tagline is italic, h1's have a small purple rule, code blocks have hairline borders.
- [ ] Tab through the app — focus indicators visible against both element and adjacent surface.
- [ ] Compare side-by-side with a Spytial-core screen — they should feel like the same product family.

🤖 Generated with [Claude Code](https://claude.com/claude-code)