### PR TITLE
Fix Edit mode add/delete sometimes producing no visible change

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sterling-layout",
   "description": "Cope and Drag (CnD): a fork of the Sterling visualizer that encodes spatial layout.",
-  "version": "4.0.2",
+  "version": "4.0.3",
   "main": "index.js",
   "author": "Siddhartha Prasad",
   "license": "MIT",

--- a/packages/sterling/src/components/EditView/EditView.tsx
+++ b/packages/sterling/src/components/EditView/EditView.tsx
@@ -8,7 +8,7 @@ import {
   selectProjectionConfig,
   selectSequencePolicyName
 } from '../../state/selectors';
-import { SpyTialEditGraph } from './SpyTialEditGraph';
+import { SpyTialEditGraph, type SpyTialEditGraphHandle } from './SpyTialEditGraph';
 import type { LayoutState } from '../GraphView/SpyTialGraph';
 import { getSpytialCore } from '../../utils/spytialCore';
 import { validateEditedInstance, ValidationIssue } from '../../utils/instanceValidation';
@@ -30,6 +30,7 @@ const EditView = () => {
 
   const layoutStateRef = useRef<LayoutState | undefined>(undefined);
   const graphElementRef = useRef<HTMLElementTagNameMap['structured-input-graph'] | null>(null);
+  const editGraphHandleRef = useRef<SpyTialEditGraphHandle | null>(null);
 
   type ExportFeedback =
     | { status: 'success'; message: string }
@@ -109,33 +110,15 @@ const EditView = () => {
     }
   }, [handleDataExported]);
 
-  const handleLoadFromInstance = useCallback(() => {
-    if (!datum?.data || !graphElementRef.current) return;
-
-    const core = getSpytialCore();
-    if (!core) return;
-
+  const handleLoadFromInstance = useCallback(async () => {
+    const handle = editGraphHandleRef.current;
+    if (!handle) return;
     try {
-      const alloyDatum = core.AlloyInstance.parseAlloyXML(datum.data);
-      if (!alloyDatum.instances || alloyDatum.instances.length === 0) return;
-
-      const instanceIndex = timeIndex !== undefined
-        ? Math.min(timeIndex, alloyDatum.instances.length - 1)
-        : 0;
-      const alloyDataInstance = new core.AlloyDataInstance(alloyDatum.instances[instanceIndex]);
-
-      if (graphElementRef.current.setDataInstance) {
-        graphElementRef.current.setDataInstance(alloyDataInstance);
-        // setDataInstance only assigns the field — trigger layout explicitly
-        const el = graphElementRef.current as any;
-        if (typeof el.enforceConstraintsAndRegenerate === 'function') {
-          el.enforceConstraintsAndRegenerate();
-        }
-      }
+      await handle.reloadFromInstance();
     } catch (err: any) {
       console.error('Failed to load instance:', err);
     }
-  }, [datum, timeIndex]);
+  }, []);
 
   return (
     <Pane className='grid grid-flow-col divide-x divide-dashed'>
@@ -216,6 +199,7 @@ const EditView = () => {
           )}
           <PaneBody>
             <SpyTialEditGraph
+              ref={editGraphHandleRef}
               datum={datum}
               cndSpec={cndSpec}
               timeIndex={timeIndex}

--- a/packages/sterling/src/components/EditView/SpyTialEditGraph.tsx
+++ b/packages/sterling/src/components/EditView/SpyTialEditGraph.tsx
@@ -1,8 +1,15 @@
 import { DatumParsed } from '@/sterling-connection';
-import { useCallback, useEffect, useRef, useState } from 'react';
+import {
+  forwardRef,
+  useCallback,
+  useEffect,
+  useImperativeHandle,
+  useRef,
+  useState,
+} from 'react';
 import { parseCndFile, type CndProjection, type SequencePolicyName } from '../../utils/cndPreParser';
 import { getSpytialCore, hasSpytialCore } from '../../utils/spytialCore';
-import type { LayoutState, TransformInfo, NodePositionHint } from '../GraphView/SpyTialGraph';
+import type { LayoutState } from '../GraphView/SpyTialGraph';
 
 // Extend HTMLElementTagNameMap for the structured-input-graph custom element
 declare global {
@@ -53,12 +60,16 @@ interface SpyTialEditGraphProps {
   graphElementRef?: React.MutableRefObject<HTMLElementTagNameMap['structured-input-graph'] | null>;
 }
 
-const SpyTialEditGraph = (props: SpyTialEditGraphProps) => {
+export interface SpyTialEditGraphHandle {
+  /** Force a reload from the current datum, discarding any in-editor edits */
+  reloadFromInstance: () => Promise<void>;
+}
+
+const SpyTialEditGraph = forwardRef<SpyTialEditGraphHandle, SpyTialEditGraphProps>((props, ref) => {
   const {
     datum,
     cndSpec,
     timeIndex,
-    priorState,
     onLayoutStateChange,
     projectionConfig = [],
     sequencePolicyName = 'ignore_history',
@@ -72,7 +83,22 @@ const SpyTialEditGraph = (props: SpyTialEditGraphProps) => {
   const [error, setError] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [isCndCoreReady, setIsCndCoreReady] = useState(hasSpytialCore());
+  // Flips true once the structured-input-graph element is mounted into the
+  // DOM. The bootstrap effect depends on this so it runs AFTER the mount
+  // effect has populated graphElementRef.current — without it, effects
+  // fire in declaration order and bootstrap would see a null ref.
+  const [graphMounted, setGraphMounted] = useState(false);
   const isInitializedRef = useRef(false);
+
+  // Tracks the last (datum.id, timeIndex) pair we successfully loaded into the
+  // editor. The bootstrap effect skips reloading the data instance when the
+  // key is unchanged, so a parent re-render with a fresh-but-equivalent datum
+  // reference will not wipe the user's in-editor edits.
+  const lastLoadedKeyRef = useRef<string | null>(null);
+
+  // Monotonic ID for each bootstrap run. Used to ignore stale completions
+  // when a new bootstrap starts before the previous one resolves.
+  const bootstrapRunIdRef = useRef(0);
 
   // Refs for props that shouldn't trigger re-layout
   const projectionConfigRef = useRef(projectionConfig);
@@ -116,16 +142,89 @@ const SpyTialEditGraph = (props: SpyTialEditGraphProps) => {
     return () => clearInterval(intervalId);
   }, [isCndCoreReady]);
 
-  // Apply CnD spec to the structured-input-graph element
-  const applyCndSpec = useCallback(() => {
-    if (!graphElementRef.current || !isCndCoreReady) return;
+  // Single serialized bootstrap: apply spec, then load data, then render —
+  // each step awaited so the next never starts before the previous finishes.
+  const runBootstrap = useCallback(async (force: boolean) => {
+    const el = graphElementRef.current;
+    if (!el || !isCndCoreReady) return;
 
-    if (cndSpec) {
-      const parsedCnd = parseCndFile(cndSpec);
-      graphElementRef.current.setAttribute('cnd-spec', parsedCnd.layoutYaml);
+    const runId = ++bootstrapRunIdRef.current;
+    const isCurrentRun = () => runId === bootstrapRunIdRef.current;
+
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      // 1. Apply the CnD spec. Use the public Promise-returning method so
+      // we can await pipeline initialization. Older spytial-core versions
+      // only expose the attribute path; fall back with a warning.
+      if (cndSpec) {
+        const parsedCnd = parseCndFile(cndSpec);
+        if (typeof el.setCnDSpec === 'function') {
+          await el.setCnDSpec(parsedCnd.layoutYaml);
+        } else {
+          console.warn(
+            '[SpyTialEditGraph] structured-input-graph.setCnDSpec missing; ' +
+            'falling back to setAttribute. Pipeline init may race with data load.'
+          );
+          el.setAttribute('cnd-spec', parsedCnd.layoutYaml);
+        }
+      }
+      if (!isCurrentRun()) return;
+
+      // 2. Load the data instance, but only when the (datum.id, timeIndex)
+      // pair has actually changed since our last load — otherwise we'd
+      // overwrite any in-editor edits the user has made.
+      const loadKey = `${datum?.id ?? ''}::${timeIndex ?? 0}`;
+      const shouldLoad = force || loadKey !== lastLoadedKeyRef.current;
+
+      if (shouldLoad && datum?.data) {
+        const core = getSpytialCore();
+        if (!core) throw new Error('spytial-core unavailable');
+
+        const alloyDatum = core.AlloyInstance.parseAlloyXML(datum.data);
+        if (alloyDatum.instances && alloyDatum.instances.length > 0) {
+          const instanceIndex = timeIndex !== undefined
+            ? Math.min(timeIndex, alloyDatum.instances.length - 1)
+            : 0;
+          const alloyDataInstance = new core.AlloyDataInstance(alloyDatum.instances[instanceIndex]);
+
+          if (el.setDataInstance) {
+            el.setDataInstance(alloyDataInstance);
+            if (typeof el.enforceConstraintsAndRegenerate === 'function') {
+              await el.enforceConstraintsAndRegenerate();
+            }
+          }
+          if (!isCurrentRun()) return;
+          lastLoadedKeyRef.current = loadKey;
+        }
+      }
+
+      if (isCurrentRun()) setIsLoading(false);
+    } catch (err: any) {
+      if (!isCurrentRun()) return;
+      console.error('[SpyTialEditGraph] bootstrap failed:', err);
+      setError(err?.message ?? 'Failed to load editor');
+      setIsLoading(false);
     }
-    setIsLoading(false);
-  }, [cndSpec, isCndCoreReady]);
+  }, [cndSpec, datum?.id, datum?.data, timeIndex, isCndCoreReady]);
+
+  // Run bootstrap when its inputs change. We deliberately key on datum.id
+  // (a stable string) rather than the datum object so a Redux selector
+  // returning a fresh-but-equivalent reference doesn't trigger a reload.
+  // graphMounted gates the first run until the mount effect has populated
+  // graphElementRef.current.
+  useEffect(() => {
+    if (!graphMounted || !graphElementRef.current || !isCndCoreReady) return;
+    runBootstrap(false);
+  }, [runBootstrap, isCndCoreReady, graphMounted]);
+
+  useImperativeHandle(ref, () => ({
+    reloadFromInstance: async () => {
+      lastLoadedKeyRef.current = null;
+      await runBootstrap(true);
+    },
+  }), [runBootstrap]);
 
   // Create and mount the structured-input-graph element once
   useEffect(() => {
@@ -143,8 +242,7 @@ const SpyTialEditGraph = (props: SpyTialEditGraphProps) => {
       display: block;
     `;
 
-    // Listen for layout-complete event for temporal continuity
-    const handleLayoutComplete = () => {
+    const captureLayoutState = () => {
       if (graphElementRef.current?.getLayoutState && onLayoutStateChangeRef.current) {
         const layoutState = graphElementRef.current.getLayoutState();
         if (layoutState && layoutState.positions && layoutState.positions.length > 0) {
@@ -153,35 +251,54 @@ const SpyTialEditGraph = (props: SpyTialEditGraphProps) => {
       }
     };
 
-    const handleNodeDragEnd = () => {
-      if (graphElementRef.current?.getLayoutState && onLayoutStateChangeRef.current) {
-        const layoutState = graphElementRef.current.getLayoutState();
-        if (layoutState && layoutState.positions && layoutState.positions.length > 0) {
-          onLayoutStateChangeRef.current(layoutState);
-        }
-      }
-    };
+    const handleLayoutComplete = () => captureLayoutState();
+    const handleNodeDragEnd = () => captureLayoutState();
+    const handleViewBoxChange = () => captureLayoutState();
 
-    const handleViewBoxChange = () => {
-      if (graphElementRef.current?.getLayoutState && onLayoutStateChangeRef.current) {
-        const layoutState = graphElementRef.current.getLayoutState();
-        if (layoutState && layoutState.positions && layoutState.positions.length > 0) {
-          onLayoutStateChangeRef.current(layoutState);
-        }
-      }
-    };
-
-    // Listen for data-exported events from the structured-input-graph
-    const handleDataExported = (e: CustomEvent) => {
+    const handleDataExported = (e: Event) => {
+      const ce = e as CustomEvent;
       if (onDataExportedRef.current) {
-        onDataExportedRef.current(e.detail.data, e.detail.format, e.detail.reified);
+        onDataExportedRef.current(ce.detail.data, ce.detail.format, ce.detail.reified);
       }
     };
+
+    // The user just made an edit inside the custom element. Pin the load key
+    // to the current (datum, timeIndex) so that any subsequent re-render of
+    // the bootstrap effect treats the data instance as already-loaded and
+    // does NOT overwrite the user's edits.
+    const handleEdited = () => {
+      lastLoadedKeyRef.current = `${datum?.id ?? ''}::${timeIndex ?? 0}`;
+      setError(null);
+    };
+
+    const handleConstraintError = (e: Event) => {
+      const ce = e as CustomEvent;
+      const msg = ce.detail?.error?.message
+        ?? ce.detail?.message
+        ?? 'Constraint conflict in edited instance';
+      setError(msg);
+    };
+
+    const handleLayoutGenerationError = (e: Event) => {
+      const ce = e as CustomEvent;
+      const msg = ce.detail?.error?.message
+        ?? ce.detail?.message
+        ?? 'Layout generation failed';
+      setError(msg);
+    };
+
+    const handleConstraintsSatisfied = () => setError(null);
 
     graphElement.addEventListener('layout-complete', handleLayoutComplete as EventListener);
     graphElement.addEventListener('node-drag-end', handleNodeDragEnd as EventListener);
     graphElement.addEventListener('viewbox-change', handleViewBoxChange as EventListener);
     graphElement.addEventListener('data-exported', handleDataExported as EventListener);
+    graphElement.addEventListener('atom-added', handleEdited as EventListener);
+    graphElement.addEventListener('atom-deleted', handleEdited as EventListener);
+    graphElement.addEventListener('relation-added', handleEdited as EventListener);
+    graphElement.addEventListener('constraint-error', handleConstraintError as EventListener);
+    graphElement.addEventListener('layout-generation-error', handleLayoutGenerationError as EventListener);
+    graphElement.addEventListener('constraints-satisfied', handleConstraintsSatisfied as EventListener);
 
     graphContainerRef.current.appendChild(graphElement);
     graphElementRef.current = graphElement;
@@ -189,6 +306,7 @@ const SpyTialEditGraph = (props: SpyTialEditGraphProps) => {
       externalGraphRef.current = graphElement;
     }
     isInitializedRef.current = true;
+    setGraphMounted(true);
 
     return () => {
       if (graphElementRef.current) {
@@ -196,6 +314,12 @@ const SpyTialEditGraph = (props: SpyTialEditGraphProps) => {
         graphElementRef.current.removeEventListener('node-drag-end', handleNodeDragEnd as EventListener);
         graphElementRef.current.removeEventListener('viewbox-change', handleViewBoxChange as EventListener);
         graphElementRef.current.removeEventListener('data-exported', handleDataExported as EventListener);
+        graphElementRef.current.removeEventListener('atom-added', handleEdited as EventListener);
+        graphElementRef.current.removeEventListener('atom-deleted', handleEdited as EventListener);
+        graphElementRef.current.removeEventListener('relation-added', handleEdited as EventListener);
+        graphElementRef.current.removeEventListener('constraint-error', handleConstraintError as EventListener);
+        graphElementRef.current.removeEventListener('layout-generation-error', handleLayoutGenerationError as EventListener);
+        graphElementRef.current.removeEventListener('constraints-satisfied', handleConstraintsSatisfied as EventListener);
 
         if (graphElementRef.current.clear) {
           graphElementRef.current.clear();
@@ -209,45 +333,12 @@ const SpyTialEditGraph = (props: SpyTialEditGraphProps) => {
         externalGraphRef.current = null;
       }
       isInitializedRef.current = false;
+      setGraphMounted(false);
     };
+    // The handlers close over `datum?.id` and `timeIndex` for the load-key
+    // refresh, but the listener set is only re-bound on mount.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
-
-  // Apply CnD spec when it changes and core is ready
-  useEffect(() => {
-    if (graphElementRef.current && isCndCoreReady) {
-      applyCndSpec();
-    }
-  }, [cndSpec, applyCndSpec, isCndCoreReady]);
-
-  // Auto-load instance from datum after CnD spec is applied so the graph
-  // starts with the correct schema (avoiding arity errors from empty instances)
-  useEffect(() => {
-    if (!graphElementRef.current || !isCndCoreReady || isLoading) return;
-    if (!datum?.data) return;
-
-    const core = getSpytialCore();
-    if (!core) return;
-
-    try {
-      const alloyDatum = core.AlloyInstance.parseAlloyXML(datum.data);
-      if (!alloyDatum.instances || alloyDatum.instances.length === 0) return;
-
-      const instanceIndex = timeIndex !== undefined
-        ? Math.min(timeIndex, alloyDatum.instances.length - 1)
-        : 0;
-      const alloyDataInstance = new core.AlloyDataInstance(alloyDatum.instances[instanceIndex]);
-
-      if (graphElementRef.current.setDataInstance) {
-        graphElementRef.current.setDataInstance(alloyDataInstance);
-        const el = graphElementRef.current as any;
-        if (typeof el.enforceConstraintsAndRegenerate === 'function') {
-          el.enforceConstraintsAndRegenerate();
-        }
-      }
-    } catch (err: any) {
-      console.error('Failed to auto-load instance:', err);
-    }
-  }, [datum, timeIndex, isCndCoreReady, isLoading]);
 
   return (
     <div
@@ -266,9 +357,13 @@ const SpyTialEditGraph = (props: SpyTialEditGraphProps) => {
         }}
       />
       {isLoading && (
+        // pointerEvents: 'auto' so the overlay swallows clicks on the
+        // toolbar inside the custom element while the CnD pipeline
+        // initializes — prevents add/delete from triggering the silent
+        // no-op render path before layoutInstance/currentLayout exist.
         <div
           className="absolute inset-0 flex items-center justify-center bg-white bg-opacity-75"
-          style={{ zIndex: 10, pointerEvents: 'none' }}
+          style={{ zIndex: 10, pointerEvents: 'auto' }}
         >
           <div className="text-gray-600">Loading editor...</div>
         </div>
@@ -283,6 +378,8 @@ const SpyTialEditGraph = (props: SpyTialEditGraphProps) => {
       )}
     </div>
   );
-};
+});
+
+SpyTialEditGraph.displayName = 'SpyTialEditGraph';
 
 export { SpyTialEditGraph };


### PR DESCRIPTION
## Summary
- Replace the async race in `SpyTialEditGraph` with a single awaited bootstrap (apply `cnd-spec` → `setDataInstance` → `enforceConstraintsAndRegenerate`), gated on a `graphMounted` state so it cannot run before the custom element is in the DOM.
- Make data loads idempotent on `(datum.id, timeIndex)` and pin the load key on `atom-added` / `atom-deleted` / `relation-added` so user edits survive parent re-renders that hand back fresh-but-equivalent datum references.
- Wire `constraint-error` / `layout-generation-error` listeners into the existing error banner; expose a `reloadFromInstance` imperative handle so `EditView`'s "Load from Instance" routes through the awaited bootstrap instead of fire-and-forgetting.

## Why
The Edit pane mounted the `structured-input-graph` element, kicked off async pipeline init via `setAttribute('cnd-spec', …)`, immediately flipped `isLoading` off, and then fired-and-forgot a second `enforceConstraintsAndRegenerate` from an auto-load effect. When the auto-load won the race, `enforceConstraintsAndRegenerate` fell through to the `layoutInstance == null` branch and called `rerenderGraph`, which itself early-returns when `currentLayout` is null — so the data instance updated but the canvas did not. The auto-load effect also keyed on the `datum` object reference, so any fresh selector result silently overwrote in-editor edits.

## Test plan
- [x] Unit: `yarn test --testPathPattern=cndPreParser` — all 13 cases pass.
- [x] Manual (mock provider): open Edit on `rc`, add `Wolf` atom programmatically → SVG node count goes 9 → 10. Delete → 10 → 9. Three sequential adds (`A1`/`A2`/`A3`) all persist on the canvas.
- [x] Edit preservation: while in Edit mode, repeated bootstraps over the same `(datum.id, timeIndex)` no longer overwrite in-editor edits (lastLoadedKeyRef).
- [x] Error surfacing: dispatching `constraint-error` shows the banner; the next `atom-added` clears it.
- [x] `Load from Instance` correctly resets to the original datum via the new `reloadFromInstance` imperative handle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)