### PR TITLE
Bump version to 4.0.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sterling-layout",
   "description": "Cope and Drag (CnD): a fork of the Sterling visualizer that encodes spatial layout.",
-  "version": "4.0.3",
+  "version": "4.0.4",
   "main": "index.js",
   "author": "Siddhartha Prasad",
   "license": "MIT",


### PR DESCRIPTION
## Summary
- Bumps app version from `4.0.3` → `4.0.4` ahead of cutting the release for the `spytial-core` 2.6.0 bump (#114).

## Test plan
- [ ] CI passes (tests + Alloy/Forge builds).

🤖 Generated with [Claude Code](https://claude.com/claude-code)