### PR TITLE
Close explorer drawer by default in the Alloy build

### DIFF
--- a/env/alloy.env
+++ b/env/alloy.env
@@ -1,1 +1,2 @@
 WS=ws://localhost:4000/alloy
+PROVIDER=alloy

--- a/env/forge.env
+++ b/env/forge.env
@@ -1,1 +1,2 @@
 WS=query
+PROVIDER=forge

--- a/env/mock.env
+++ b/env/mock.env
@@ -1,1 +1,2 @@
 WS=mock
+PROVIDER=mock

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sterling-layout",
   "description": "Cope and Drag (CnD): a fork of the Sterling visualizer that encodes spatial layout.",
-  "version": "4.0.4",
+  "version": "4.0.5",
   "main": "index.js",
   "author": "Siddhartha Prasad",
   "license": "MIT",

--- a/packages/sterling/src/state/ui/ui.ts
+++ b/packages/sterling/src/state/ui/ui.ts
@@ -35,10 +35,13 @@ export interface UiState {
  * Create a new UI state.
  */
 export const newUiState = (initialView?: MainView): UiState => {
+  // In the Alloy build, start with the explorer drawer closed so the graph
+  // gets the full width by default. It can be reopened via the sidebar button.
+  const explorerClosedByDefault = process.env.PROVIDER === 'alloy';
   return {
     availableViews: ['GraphView', 'TableView', 'ScriptView', 'EditView'],
     mainView: initialView || 'ScriptView',
-    graphViewDrawer: 'explorer',
+    graphViewDrawer: explorerClosedByDefault ? null : 'explorer',
     tableViewDrawer: null,
     scriptViewDrawer: 'variables',
     editViewDrawer: null,


### PR DESCRIPTION
## What

Close the explorer drawer by default in the **Alloy build** so the graph gets the full width on load. The explorer (the right-pane instance drawer) previously opened by default in Graph view at 350px, taking a large share of the width — noticeable on smaller screens.

It remains one click away via the **Explorer** button in the right sidebar (which highlights when active), so nothing is hidden — users just opt in.

## How

- `newUiState()` initializes `graphViewDrawer` to `null` (collapsed) when `process.env.PROVIDER === 'alloy'`, otherwise `'explorer'` as before. The collapse itself reuses the existing `selectDrawerIsCollapsed` → `Dashboard` path — no new layout logic.
- Added a `PROVIDER` env var to each build's env file (`alloy` / `forge` / `mock`), mirroring how `WS` is already wired and inlined by dotenv-webpack.

## Scope

- **Alloy:** explorer closed by default.
- **Forge / Mock:** unchanged — explorer open by default.

## Verification

Built the Alloy bundle (dev mode) and confirmed the env var inlines and the initializer resolves to closed:

- `explorerClosedByDefault = "alloy" === 'alloy'` → `true`
- `graphViewDrawer: explorerClosedByDefault ? null : 'explorer'` → `null` → drawer starts collapsed

The visible Graph-view state requires the Alloy WS backend to load an instance, which wasn't available in this environment, so it wasn't exercised in a browser. Forge/Mock weren't rebuilt — `"forge"`/`"mock" === 'alloy'` is trivially `false`, so their default is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
