### PR TITLE
fix(alloy-proxy): render subset (`in`) sigs without crashing

### DIFF
--- a/packages/sterling/src/components/ScriptView/alloy-proxy/AlloyAtom.ts
+++ b/packages/sterling/src/components/ScriptView/alloy-proxy/AlloyAtom.ts
@@ -47,6 +47,15 @@ class AlloyAtom extends AlloySet {
 
         const label = element.getAttribute('label');
         if (!label) throw AlloyError.missingAttribute('AlloyAtom', 'label');
+
+        // The same atom can be listed under more than one signature — e.g. a subset (`in`) sig
+        // re-lists atoms that already belong to its parent sig. Atoms are identical up to their ID,
+        // so reuse the already-proxied atom rather than re-proxying it (which throws on a duplicate).
+        if (proxy) {
+            const existing = proxy.get(varName(label));
+            if (existing) return existing as AlloyAtom;
+        }
+
         return new AlloyAtom(label, proxy);
 
     }

--- a/packages/sterling/src/components/ScriptView/alloy-proxy/AlloyProxy.ts
+++ b/packages/sterling/src/components/ScriptView/alloy-proxy/AlloyProxy.ts
@@ -76,6 +76,16 @@ class AlloyProxy {
 
     }
 
+    /**
+     * The proxied set previously registered under `id`, if any. Lets callers reuse an existing
+     * atom/signature instead of re-proxying it (which throws on a duplicate ID) — needed because
+     * the same atom can legitimately appear under more than one signature (e.g. an `in` subset sig
+     * re-lists atoms that already belong to its parent sig).
+     */
+    get (id: string): AlloySet | undefined {
+        return this._sets.get(id);
+    }
+
     private _finalize (set: AlloySet): AlloySet {
 
         if (set.tuples().length === 1 && set.tuples()[0].atoms().length === 1) {

--- a/packages/sterling/src/components/ScriptView/alloy-proxy/test/AlloySubsetSig.test.ts
+++ b/packages/sterling/src/components/ScriptView/alloy-proxy/test/AlloySubsetSig.test.ts
@@ -1,0 +1,44 @@
+/**
+ * @jest-environment jsdom
+ */
+import { AlloySignature } from '../AlloySignature'
+import { AlloyProxy } from '../AlloyProxy'
+
+// An instance with a subset (`in`) signature: `Active in Node`. Alloy's XML lists Active's member
+// atoms (Node$0, Node$1) which already belong to the parent sig Node, and marks the subset with a
+// <type> child. Parsing this used to throw "Cannot apply proxy, ID already exists: Node$0".
+const SUBSET_XML = `<instance bitwidth="4">
+  <sig label="univ" ID="2" builtin="yes"></sig>
+  <sig label="this/Node" ID="4" parentID="2">
+    <atom label="Node$0"/><atom label="Node$1"/><atom label="Node$2"/>
+  </sig>
+  <sig label="this/Active" ID="5" var="yes">
+    <atom label="Node$0"/><atom label="Node$1"/>
+    <type ID="4"/>
+  </sig>
+</instance>`
+
+function parseSigs(): Map<string, AlloySignature> {
+  const doc = new DOMParser().parseFromString(SUBSET_XML, 'text/xml')
+  const instance = doc.querySelector('instance')!
+  return AlloySignature.signaturesFromXML(instance, new AlloyProxy())
+}
+
+describe('signaturesFromXML with subset (`in`) signatures', () => {
+  it('does not throw when an atom appears under both a parent sig and an `in` subset sig', () => {
+    expect(() => parseSigs()).not.toThrow()
+  })
+
+  it('the subset sig contains the shared atoms', () => {
+    const sigs = parseSigs()
+    const active = sigs.get('5')!
+    expect(active.atoms().map(a => a.id()).sort()).toEqual(['Node$0', 'Node$1'])
+  })
+
+  it('reuses the parent atom objects rather than duplicating them', () => {
+    const sigs = parseSigs()
+    const node = sigs.get('4')!
+    const active = sigs.get('5')!
+    expect(active.atom('Node$0')).toBe(node.atom('Node$0'))
+  })
+})


### PR DESCRIPTION
## Problem
Parsing an Alloy instance with a subset (`in`) signature crashes the visualizer (blank screen):
```
Error: [AlloyProxy] Cannot apply proxy, ID already exists: Node$0.
(This may be caused by a clash between sig and atom names.)
```
`AlloyAtom.fromElement` re-proxies every `<atom>` it parses. A subset sig (e.g. `Active in Node`) re-lists atoms that already belong to its parent sig (`Node$0` appears under both `Node` and `Active`), so the second `applyProxy` throws and the whole render aborts.

## Fix
Atoms are identical up to their ID, so reuse the already-proxied atom instead of re-proxying it. Adds `AlloyProxy.get(id)` and makes `AlloyAtom.fromElement` idempotent (also covers fields/skolems that reference existing atoms).

## Tests
New `AlloySubsetSig.test.ts`: a subset-sig instance parses without throwing and the subset shares the parent's atom objects. All alloy-proxy tests pass (11/11).

## Verification
A `var sig Active in Node` temporal model that previously rendered **nothing** now renders in the `build:forge` output (graph + time controls, no console errors).

Note: `spytial-core`'s parser already filters subset sigs (via `sigElementIsSet`), so it does not need this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)