### PR TITLE
Show layout/parse errors above the graph instead of in the Layout tab

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sterling-layout",
   "description": "Cope and Drag (CnD): a fork of the Sterling visualizer that encodes spatial layout.",
-  "version": "4.0.5",
+  "version": "4.0.6",
   "main": "index.js",
   "author": "Siddhartha Prasad",
   "license": "MIT",

--- a/packages/sterling/src/components/AppDrawer/graph/theme/GraphLayoutDrawer.tsx
+++ b/packages/sterling/src/components/AppDrawer/graph/theme/GraphLayoutDrawer.tsx
@@ -4,7 +4,7 @@ import { useSterlingDispatch, useSterlingSelector } from '../../../../state/hook
 import { selectActiveDatum, selectCnDSpec, selectSelectedProjections, selectTimeIndex, selectProjectionConfig, selectSequencePolicyName } from '../../../../state/selectors';
 import { cndSpecSet, selectedProjectionsSet } from '../../../../state/graphs/graphsSlice';
 import { parseCndFile } from '../../../../utils/cndPreParser';
-import { getSpytialCore } from '../../../../utils/spytialCore';
+import { ensureBootstrapLoaded, getSpytialCore } from '../../../../utils/spytialCore';
 import * as yaml from 'js-yaml';
 
 /**
@@ -37,9 +37,7 @@ const GraphLayoutDrawer = () => {
   const dispatch = useSterlingDispatch();
   const datum = useSterlingSelector(selectActiveDatum);
   const cndEditorRef = useRef<HTMLDivElement>(null);
-  const errorMountRef = useRef<HTMLDivElement>(null);
   const [isEditorMounted, setIsEditorMounted] = useState(false);
-  const [isErrorMounted, setIsErrorMounted] = useState(false);
 
   // Preserve the projections/sequence blocks that were stripped from the
   // editor so we can merge them back when "Apply Layout" is clicked.
@@ -138,31 +136,10 @@ const GraphLayoutDrawer = () => {
     }
   }, [datum, timeIndex, selectedProjections]);
 
-  // Load Bootstrap for SpyTial UI
+  // Load Bootstrap for SpyTial UI (used by the mounted CnD editor below).
   useEffect(() => {
-    const existingBootstrap = document.getElementById('spytial-bootstrap-stylesheet');
-    if (!existingBootstrap) {
-      const link = document.createElement('link');
-      link.id = 'spytial-bootstrap-stylesheet';
-      link.rel = 'stylesheet';
-      link.href = 'https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css';
-      link.integrity = 'sha384-9ndCyUaIbzAi2FUVXJi0CjmCapSmO7SnpJef0486qhLnuZ2cdeRhO02iuK6FUUVM';
-      link.crossOrigin = 'anonymous';
-      document.head.appendChild(link);
-    }
+    ensureBootstrapLoaded();
   }, []);
-
-  // Mount SpyTial error modal
-  useEffect(() => {
-    if (errorMountRef.current && window.mountErrorMessageModal && !isErrorMounted) {
-      try {
-        window.mountErrorMessageModal('layout-error-mount');
-        setIsErrorMounted(true);
-      } catch (err) {
-        console.error('Failed to mount SpyTial Error Modal:', err);
-      }
-    }
-  }, [isErrorMounted]);
 
   // Mount the CnD Layout Interface from SpyTial
   useEffect(() => {
@@ -274,14 +251,6 @@ const GraphLayoutDrawer = () => {
 
   return (
     <div className="absolute inset-0 flex flex-col overflow-y-auto bg-slate-50/90 text-slate-900">
-      {/* Error display area */}
-      <div
-        id="layout-error-mount"
-        ref={errorMountRef}
-        className="flex-shrink-0"
-        aria-live="polite"
-      />
-
       <div className="flex-1 space-y-3 p-3">
         {/* Actions */}
         <div className="flex gap-2">

--- a/packages/sterling/src/components/GraphView/GraphView.tsx
+++ b/packages/sterling/src/components/GraphView/GraphView.tsx
@@ -1,6 +1,7 @@
 import { Pane, PaneBody, PaneHeader } from '@/sterling-ui';
-import { useCallback, useMemo, useRef } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useSterlingDispatch, useSterlingSelector } from '../../state/hooks';
+import { ensureBootstrapLoaded } from '../../utils/spytialCore';
 import { 
   selectActiveDatum, 
   selectCnDSpec, 
@@ -219,6 +220,42 @@ const GraphView = () => {
     }
   }, [dispatch, isSynthesisActive]);
 
+  // SpyTial's error modal is a singleton bound to spytial-core's global error
+  // manager. We mount it once, directly above the graph, so parse/layout errors
+  // raised during rendering are visible no matter which drawer tab is open —
+  // previously it lived inside the Layout drawer and was hidden on other tabs.
+  const errorMountRef = useRef<HTMLDivElement>(null);
+  const [isErrorMounted, setIsErrorMounted] = useState(false);
+
+  // The error modal is styled with Bootstrap; make sure it's loaded.
+  useEffect(() => {
+    ensureBootstrapLoaded();
+  }, []);
+
+  useEffect(() => {
+    if (isErrorMounted) return;
+
+    const tryMount = (): boolean => {
+      if (!errorMountRef.current || !window.mountErrorMessageModal) return false;
+      try {
+        window.mountErrorMessageModal('graph-error-mount');
+        setIsErrorMounted(true);
+        return true;
+      } catch (err) {
+        console.error('Failed to mount SpyTial Error Modal:', err);
+        return false;
+      }
+    };
+
+    // The global bundle is normally ready at boot, but poll briefly in case the
+    // mount node or the global isn't available on the first pass.
+    if (tryMount()) return;
+    const intervalId = setInterval(() => {
+      if (tryMount()) clearInterval(intervalId);
+    }, 200);
+    return () => clearInterval(intervalId);
+  }, [isErrorMounted]);
+
   // Determine if we should show multiple graphs
   const shouldShowMultiProjection = 
     multiProjectionInfo !== null &&
@@ -282,8 +319,18 @@ const GraphView = () => {
             <PaneHeader className='border-b'>
               <GraphViewHeader datum={datum} />
             </PaneHeader>
-            <PaneBody>
-              {renderGraphContent()}
+            <PaneBody display="flex" flexDirection="column">
+              {/* SpyTial error modal mounts here — sits above the graph and
+                  collapses to nothing when there is no active error. */}
+              <div
+                id="graph-error-mount"
+                ref={errorMountRef}
+                className="flex-shrink-0 px-2"
+                aria-live="polite"
+              />
+              <div className="relative flex-1 min-h-0">
+                {renderGraphContent()}
+              </div>
             </PaneBody>
           </Pane>
         </div>

--- a/packages/sterling/src/utils/spytialCore.ts
+++ b/packages/sterling/src/utils/spytialCore.ts
@@ -112,3 +112,25 @@ export function getSpytialCore(): SpytialCoreApi | undefined {
 export function hasSpytialCore(): boolean {
   return typeof getSpytialCore() !== 'undefined';
 }
+
+/**
+ * Ensure the SpyTial Bootstrap stylesheet is present in <head>.
+ *
+ * SpyTial's mounted React components — the CnD layout editor and the error
+ * message modal — are styled with Bootstrap utility classes (`card`,
+ * `border-danger`, `var(--bs-danger)`, …) that the component CSS bundle does
+ * not ship. The stylesheet is injected lazily and only once, no matter how
+ * many components request it.
+ */
+export function ensureBootstrapLoaded(): void {
+  if (typeof document === 'undefined') return;
+  if (document.getElementById('spytial-bootstrap-stylesheet')) return;
+
+  const link = document.createElement('link');
+  link.id = 'spytial-bootstrap-stylesheet';
+  link.rel = 'stylesheet';
+  link.href = 'https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css';
+  link.integrity = 'sha384-9ndCyUaIbzAi2FUVXJi0CjmCapSmO7SnpJef0486qhLnuZ2cdeRhO02iuK6FUUVM';
+  link.crossOrigin = 'anonymous';
+  document.head.appendChild(link);
+}


### PR DESCRIPTION
## Problem

When `SpyTialGraph` raised a layout/parse error, the spytial-core error modal was mounted inside `GraphLayoutDrawer` (`#layout-error-mount`). Because that drawer only renders when `drawer === 'layout'`, the error was **invisible on every other drawer tab** (Time, Projections, Explorer, Synthesis, Log) — even though those errors come from the graph, not the Layout editor. The mount node also unmounted/remounted on every tab switch, orphaning spytial-core's React root each time.

## Change

Mount the error modal **once in `GraphView`, directly above the graph**, where it's visible no matter which drawer tab is active.

- `GraphView.tsx` — mounts the modal into `#graph-error-mount` above the graph (flex column). It collapses to 0 height when there's no error and reflows the graph down when one is present.
- `spytialCore.ts` — extracted `ensureBootstrapLoaded()`; the error card uses Bootstrap classes, which were previously loaded only by the Layout drawer. The graph view now ensures they're present.
- `GraphLayoutDrawer.tsx` — removed the error mount/div/state; reuses the shared Bootstrap helper for the CnD editor.

The error-*triggering* code in `SpyTialGraph` is unchanged — only where the modal renders moved.

## Verified (mock provider)

- Error renders above the graph while on the **Explorer** tab (previously hidden there).
- Properly styled — Bootstrap loads from the graph view, not the Layout tab.
- Reflow: graph shrinks when an error is shown (604px → 400px) and returns to full height when cleared.
- Layout tab still works (editor + Apply Layout); old `#layout-error-mount` removed.
- No new type errors, no new console errors.

Note: `SpyTialGraph`'s own bottom banner (render/no-instance errors) is intentionally left as-is — it covers a disjoint error set.

Patch version bumped 4.0.5 → 4.0.6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)