### PR TITLE
Add app-wide dark mode, synced two-way with the graph's theme

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sterling-layout",
   "description": "Cope and Drag (CnD): a fork of the Sterling visualizer that encodes spatial layout.",
-  "version": "4.0.7",
+  "version": "4.0.8",
   "main": "index.js",
   "author": "Siddhartha Prasad",
   "license": "MIT",
@@ -60,7 +60,7 @@
     "react-monaco-editor": "^0.47.0",
     "react-redux": "^7.2.6",
     "redux": "^4.1.2",
-    "spytial-core": "2.7.1",
+    "spytial-core": "2.8.0",
     "transformation-matrix": "^2.10.0",
     "ts-is-present": "^1.2.2",
     "uuid": "^9.0.0"

--- a/packages/sterling-ui/src/components/MiniMap/styles.ts
+++ b/packages/sterling-ui/src/components/MiniMap/styles.ts
@@ -2,14 +2,14 @@ import { LabelDef, ShapeDef } from '@/graph-svg';
 import { CSSProperties } from 'react';
 
 export const edgeStyle: CSSProperties = {
-  stroke: '#4A5568',
+  stroke: 'var(--ccd-minimap-edge)',
   strokeWidth: 1,
   fill: 'none'
 };
 
 export const nodeLabel: Omit<LabelDef, 'text'> = {
   style: {
-    fill: '#4A5568',
+    fill: 'var(--ccd-minimap-node-stroke)',
     fontFamily: 'monospace',
     fontSize: '10px',
     textAnchor: 'middle',
@@ -27,9 +27,9 @@ export const nodeShape: ShapeDef = {
 };
 
 export const nodeStyle: CSSProperties = {
-  stroke: '#4A5568',
+  stroke: 'var(--ccd-minimap-node-stroke)',
   strokeWidth: 1,
-  fill: 'white',
+  fill: 'var(--ccd-minimap-node-fill)',
   cursor: 'pointer'
 };
 
@@ -47,8 +47,8 @@ export const selectedNodeLabel: Omit<LabelDef, 'text'> = {
 };
 
 export const selectedNodeStyle: CSSProperties = {
-  stroke: '#333',
+  stroke: 'var(--ccd-minimap-selected-stroke)',
   strokeWidth: 1,
-  fill: 'white',
+  fill: 'var(--ccd-minimap-node-fill)',
   cursor: 'pointer'
 };

--- a/packages/sterling-ui/src/themeVars.css
+++ b/packages/sterling-ui/src/themeVars.css
@@ -1,0 +1,170 @@
+/*
+ * Cope-and-Drag theme variables — the single source of truth for app colors.
+ *
+ * `tokens.ts` maps every `tokens.color.*` to one of these `var(--ccd-*)`
+ * properties, and `tailwind.config.cjs` maps its semantic colors to the same
+ * vars. Flipping `data-theme` on <html> (see state/theme) re-themes the Chakra
+ * theme, all component themes, inline token usages, and Tailwind utilities at
+ * once — no `dark:` variants and no React re-render required.
+ *
+ * Light values are the historical palette (kept identical). Dark values are a
+ * warm-neutral set tuned for WCAG AA, anchored on the graph's #1e1e1e canvas.
+ */
+
+:root,
+[data-theme='light'] {
+  /* Surfaces */
+  --ccd-bg: #fdfdfb;
+  --ccd-surface: #ffffff;
+  --ccd-surface-muted: #f4f3ef;
+  --ccd-surface-sunken: #ececea;
+
+  /* Ink (text) */
+  --ccd-ink: #1f2937;
+  --ccd-ink-muted: #475569;
+  --ccd-ink-faint: #64748b;
+  --ccd-ink-decorative: #adb5bd;
+
+  /* Hairline rules */
+  --ccd-rule: #e9ecef;
+  --ccd-rule-strong: #dee2e6;
+
+  /* Accent */
+  --ccd-accent: #5a3d8a;
+  --ccd-accent-bg: #f0eef8;
+  --ccd-accent-border: #c4b8e0;
+  --ccd-accent-ink: #3d2a5e;
+  --ccd-on-accent: #ffffff;
+
+  /* Code surface (already dark in both modes) */
+  --ccd-code-bg: #1e1e1e;
+  --ccd-code-fg: #d4d4d4;
+  --ccd-code-muted: #9b9b9b;
+
+  /* Status — base text, subtle background, and border for tinted panels */
+  --ccd-success: #1b5e20;
+  --ccd-success-bg: #ecfdf3;
+  --ccd-success-border: #b7e4c7;
+  --ccd-error: #a31515;
+  --ccd-danger: #b42318;
+  --ccd-danger-bg: #fef3f2;
+  --ccd-danger-border: #fcc8c3;
+  --ccd-warning: #8a6d00;
+  --ccd-warning-bg: #fffaeb;
+  --ccd-warning-border: #fde68a;
+  --ccd-info: #1d4ed8;
+  --ccd-info-bg: #eff6ff;
+  --ccd-info-border: #bfdbfe;
+
+  /* Translucent scrim for loading overlays (over the canvas/surface) */
+  --ccd-overlay: rgba(255, 255, 255, 0.72);
+
+  /* Minimap (SVG fills/strokes applied via inline style objects) */
+  --ccd-minimap-bg: #ffffff;
+  --ccd-minimap-node-fill: #ffffff;
+  --ccd-minimap-node-stroke: #4a5568;
+  --ccd-minimap-node-active: #3b82f6;
+  --ccd-minimap-edge: #4a5568;
+  --ccd-minimap-selected-stroke: #333333;
+}
+
+/*
+ * Chakra's ColorModeProvider stamps a `chakra-ui-light` class on <body> and
+ * paints its own (light) body background. `html body` (specificity 0,0,0,2)
+ * outranks Chakra's `body` rule without !important, so the document root always
+ * follows our theme — no white flash on load or in layout gaps.
+ */
+html {
+  /* Root backstop so the page is themed even before React mounts / in any gap. */
+  background-color: var(--ccd-bg);
+}
+
+/*
+ * Tailwind's typography plugin (`prose`, used by the Table view) hardcodes a
+ * gray text palette via --tw-prose-* variables; remap it to the themed ink in
+ * dark mode so table text stays legible.
+ */
+/*
+ * spytial-core's embedded CnD editor widget (Layout drawer: Code View /
+ * Structured Builder) hardcodes a white form background; theme it in dark mode
+ * via its stable class names. Light mode is untouched.
+ */
+[data-theme='dark'] .cnd-layout-interface textarea,
+[data-theme='dark'] .cnd-layout-interface .form-control,
+[data-theme='dark'] .code-view-textarea {
+  background-color: var(--ccd-surface-muted);
+  color: var(--ccd-ink);
+  border-color: var(--ccd-rule-strong);
+}
+
+[data-theme='dark'] .prose {
+  --tw-prose-body: var(--ccd-ink-muted);
+  --tw-prose-headings: var(--ccd-ink);
+  --tw-prose-lead: var(--ccd-ink-muted);
+  --tw-prose-bold: var(--ccd-ink);
+  --tw-prose-captions: var(--ccd-ink-muted);
+  --tw-prose-code: var(--ccd-ink);
+  --tw-prose-th-borders: var(--ccd-rule-strong);
+  --tw-prose-td-borders: var(--ccd-rule);
+  color: var(--ccd-ink-muted);
+}
+html body {
+  background-color: var(--ccd-bg);
+  color: var(--ccd-ink);
+}
+
+[data-theme='dark'] {
+  /* Surfaces */
+  --ccd-bg: #16181d;
+  --ccd-surface: #1e2127;
+  --ccd-surface-muted: #262a31;
+  --ccd-surface-sunken: #2c313a;
+
+  /* Ink (text) */
+  --ccd-ink: #e6e7ea;
+  --ccd-ink-muted: #aab2c0;
+  --ccd-ink-faint: #7e8694;
+  --ccd-ink-decorative: #5b626e;
+
+  /* Hairline rules */
+  --ccd-rule: #2e333c;
+  --ccd-rule-strong: #3a404a;
+
+  /* Accent (lightened so it reads on dark) */
+  --ccd-accent: #b9a3e3;
+  --ccd-accent-bg: #2a2440;
+  --ccd-accent-border: #4a3f6b;
+  --ccd-accent-ink: #d9ccf2;
+  --ccd-on-accent: #1b1228;
+
+  /* Code surface (slightly sunken vs. surface) */
+  --ccd-code-bg: #141519;
+  --ccd-code-fg: #d4d4d4;
+  --ccd-code-muted: #9b9b9b;
+
+  /* Status (lightened for contrast on dark; subtle bgs are low-chroma tints) */
+  --ccd-success: #6cc070;
+  --ccd-success-bg: #1d3026;
+  --ccd-success-border: #2f5a3f;
+  --ccd-error: #f08a8a;
+  --ccd-danger: #f08a8a;
+  --ccd-danger-bg: #3a2526;
+  --ccd-danger-border: #5e3434;
+  --ccd-warning: #e0b95c;
+  --ccd-warning-bg: #3a3320;
+  --ccd-warning-border: #5a4d2a;
+  --ccd-info: #79b8f3;
+  --ccd-info-bg: #1c2a3c;
+  --ccd-info-border: #2e4a6b;
+
+  /* Translucent scrim for loading overlays */
+  --ccd-overlay: rgba(22, 24, 29, 0.72);
+
+  /* Minimap */
+  --ccd-minimap-bg: #1e2127;
+  --ccd-minimap-node-fill: #2b2f37;
+  --ccd-minimap-node-stroke: #8b919b;
+  --ccd-minimap-node-active: #5dade2;
+  --ccd-minimap-edge: #6b7280;
+  --ccd-minimap-selected-stroke: #e6e7ea;
+}

--- a/packages/sterling-ui/src/tokens.ts
+++ b/packages/sterling-ui/src/tokens.ts
@@ -18,31 +18,34 @@ export const tokens = {
     body: '"Atkinson Hyperlegible", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif',
     mono: '"Fira Code VF", "Fira Code", ui-monospace, SFMono-Regular, Menlo, Consolas, monospace'
   },
+  // Each color resolves to a CSS custom property (see themeVars.css), so the
+  // whole shell re-themes when `data-theme` flips on <html>. Light values (the
+  // historical palette) and dark values live in themeVars.css.
   color: {
-    bg: '#fdfdfb',
-    surface: '#ffffff',
-    surfaceMuted: '#f4f3ef',
+    bg: 'var(--ccd-bg)',
+    surface: 'var(--ccd-surface)',
+    surfaceMuted: 'var(--ccd-surface-muted)',
 
-    ink: '#1f2937',
-    inkMuted: '#475569',
-    inkFaint: '#64748b',
-    inkDecorative: '#adb5bd',
+    ink: 'var(--ccd-ink)',
+    inkMuted: 'var(--ccd-ink-muted)',
+    inkFaint: 'var(--ccd-ink-faint)',
+    inkDecorative: 'var(--ccd-ink-decorative)',
 
-    rule: '#e9ecef',
-    ruleStrong: '#dee2e6',
+    rule: 'var(--ccd-rule)',
+    ruleStrong: 'var(--ccd-rule-strong)',
 
-    accent: '#5a3d8a',
-    accentBg: '#f0eef8',
-    accentBorder: '#c4b8e0',
-    accentInk: '#3d2a5e',
+    accent: 'var(--ccd-accent)',
+    accentBg: 'var(--ccd-accent-bg)',
+    accentBorder: 'var(--ccd-accent-border)',
+    accentInk: 'var(--ccd-accent-ink)',
 
-    codeBg: '#1e1e1e',
-    codeFg: '#d4d4d4',
-    codeMuted: '#9b9b9b',
+    codeBg: 'var(--ccd-code-bg)',
+    codeFg: 'var(--ccd-code-fg)',
+    codeMuted: 'var(--ccd-code-muted)',
 
-    success: '#1b5e20',
-    error: '#a31515',
-    warning: '#8a6d00'
+    success: 'var(--ccd-success)',
+    error: 'var(--ccd-error)',
+    warning: 'var(--ccd-warning)'
   },
   focus: {
     width: '2px',

--- a/packages/sterling/src/components/AppDrawer/common/EvaluatorDrawer/EvaluatorDrawer.tsx
+++ b/packages/sterling/src/components/AppDrawer/common/EvaluatorDrawer/EvaluatorDrawer.tsx
@@ -29,7 +29,7 @@ const EvaluatorDrawer = () => {
 
 const TemporalEvaluatorNotice = () => {
   return (
-    <div className='mx-2 mt-2 rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-900'>
+    <div className='mx-2 mt-2 rounded-md border border-warning-border bg-warning-bg px-3 py-2 text-xs text-warning'>
       Temporal mode: evaluator expressions run with respect to the first
       state, not the currently displayed state.
     </div>

--- a/packages/sterling/src/components/AppDrawer/common/EvaluatorDrawer/EvaluatorExpressions.tsx
+++ b/packages/sterling/src/components/AppDrawer/common/EvaluatorDrawer/EvaluatorExpressions.tsx
@@ -19,7 +19,7 @@ const EvaluatorExpression = (props: EvaluatorExpressionProps) => {
         </span>
         <div className='font-semibold select-text'>{expression.expression}</div>
       </div>
-      <div className='ml-6 text-gray-600 select-text'>{expression.result}</div>
+      <div className='ml-6 text-ink-muted select-text'>{expression.result}</div>
     </div>
   );
 };

--- a/packages/sterling/src/components/AppDrawer/common/EvaluatorDrawer/EvaluatorInput.tsx
+++ b/packages/sterling/src/components/AppDrawer/common/EvaluatorDrawer/EvaluatorInput.tsx
@@ -87,7 +87,7 @@ const EvaluatorInput = (props: EvaluatorInputProps) => {
           <Icon color={iconColor} as={GoChevronRight} />
         </span>
         <input
-          className='h-[35px] text-xs placeholder:italic placeholder:text-gray-400 placeholder:text-xs block bg-white w-full border-b border-gray-100 focus:border-gray-200 py-2 pl-9 pr-3 focus:outline-none'
+          className='h-[35px] text-xs placeholder:italic placeholder:text-ink-faint placeholder:text-xs block bg-surface w-full border-b border-rule focus:border-rule py-2 pl-9 pr-3 focus:outline-none'
           placeholder={placeholder}
           type='text'
           disabled={!active}

--- a/packages/sterling/src/components/AppDrawer/common/explorer/ListView/ListViewDatumItem.tsx
+++ b/packages/sterling/src/components/AppDrawer/common/explorer/ListView/ListViewDatumItem.tsx
@@ -25,7 +25,7 @@ const ListViewDatumItem = (props: ListViewDatumItemProps) => {
   const statefulProjected = useSterlingSelector((state) =>
     selectDatumIsStatefulProjected(state, datum)
   );
-  const cn = active ? 'text-white bg-blue-600' : '';
+  const cn = active ? 'text-on-accent bg-accent' : '';
 
   return (
     <Row onClick={(event) => onClickItem(event, datum)}>

--- a/packages/sterling/src/components/AppDrawer/common/explorer/ListView/Row.tsx
+++ b/packages/sterling/src/components/AppDrawer/common/explorer/ListView/Row.tsx
@@ -16,7 +16,7 @@ const RowItem = (props: HTMLAttributes<HTMLDivElement>) => {
   return (
     <div
       className={`
-        flex items-center prose prose-sm truncate px-1 py-0.5 first:pl-2 last:pr-2 group-hover:bg-blue-600 group-active:bg-blue-700 group-hover:text-white select-none cursor-default group-hover:cursor-pointer ${
+        flex items-center prose prose-sm truncate px-1 py-0.5 first:pl-2 last:pr-2 group-hover:bg-accent group-active:bg-accent group-hover:text-on-accent select-none cursor-default group-hover:cursor-pointer ${
           className || ''
         }`}
       {...rest}

--- a/packages/sterling/src/components/AppDrawer/graph/projections/GraphProjectionsDrawer.tsx
+++ b/packages/sterling/src/components/AppDrawer/graph/projections/GraphProjectionsDrawer.tsx
@@ -116,8 +116,8 @@ const GraphProjectionsDrawer = () => {
   if (!activeDatum) {
     return (
       <div className='absolute inset-0 flex flex-col overflow-y-auto'>
-        <div className='mx-2 mt-2 rounded-lg border border-slate-200 bg-white p-3 shadow-sm'>
-          <p className='text-xs text-gray-500'>
+        <div className='mx-2 mt-2 rounded-lg border border-rule bg-surface p-3 shadow-sm'>
+          <p className='text-xs text-ink-muted'>
             No active instance. Run a model to configure projections.
           </p>
         </div>
@@ -128,8 +128,8 @@ const GraphProjectionsDrawer = () => {
   return (
     <div className='absolute inset-0 flex flex-col overflow-y-auto'>
       {/* ── Add Projection ─────────────────────────────────────── */}
-      <div className='mx-2 mt-2 mb-1 rounded-lg border border-slate-200 bg-white p-3 shadow-sm'>
-        <span className='text-sm font-semibold text-gray-800'>
+      <div className='mx-2 mt-2 mb-1 rounded-lg border border-rule bg-surface p-3 shadow-sm'>
+        <span className='text-sm font-semibold text-ink'>
           Add Projection
         </span>
         {availableTypes.length > 0 && (
@@ -139,7 +139,7 @@ const GraphProjectionsDrawer = () => {
                 key={typeName}
                 type='button'
                 onClick={() => handleAddProjection(typeName)}
-                className='px-2.5 py-1 text-xs rounded-md font-medium bg-emerald-50 text-emerald-700 border border-emerald-200 hover:bg-emerald-100 transition-colors'
+                className='px-2.5 py-1 text-xs rounded-md font-medium bg-success-bg text-success border border-success-border hover:bg-success-bg transition-colors'
               >
                 + {typeName}
               </button>
@@ -154,13 +154,13 @@ const GraphProjectionsDrawer = () => {
             onChange={(e) => setManualType(e.target.value)}
             onKeyDown={(e) => { if (e.key === 'Enter') handleManualAdd(); }}
             placeholder='Type name (e.g. State)'
-            className='flex-1 px-2 py-1 text-xs rounded-md border border-gray-200 bg-gray-50 focus:outline-none focus:border-indigo-300 focus:ring-1 focus:ring-indigo-200'
+            className='flex-1 px-2 py-1 text-xs rounded-md border border-rule bg-surface-muted focus:outline-none focus:border-accent-border focus:ring-1 focus:ring-accent'
           />
           <button
             type='button'
             onClick={handleManualAdd}
             disabled={!manualType.trim()}
-            className='px-2.5 py-1 text-xs rounded-md font-medium bg-indigo-600 text-white hover:bg-indigo-700 disabled:bg-gray-300 disabled:cursor-not-allowed transition-colors'
+            className='px-2.5 py-1 text-xs rounded-md font-medium bg-accent text-on-accent hover:bg-accent disabled:bg-surface-sunken disabled:cursor-not-allowed transition-colors'
           >
             Add
           </button>
@@ -169,20 +169,20 @@ const GraphProjectionsDrawer = () => {
 
       {/* ── Active Projections ─────────────────────────────────── */}
       {currentProjections.length > 0 && (
-        <div className='mx-2 mt-1 mb-1 rounded-lg border border-slate-200 bg-white p-3 shadow-sm'>
-          <span className='text-sm font-semibold text-gray-800'>
+        <div className='mx-2 mt-1 mb-1 rounded-lg border border-rule bg-surface p-3 shadow-sm'>
+          <span className='text-sm font-semibold text-ink'>
             Active Projections
           </span>
           <div className='mt-2 space-y-1.5'>
             {currentProjections.map((proj) => (
               <div
                 key={proj.type}
-                className='flex items-center justify-between rounded-md bg-indigo-50 px-2.5 py-1.5'
+                className='flex items-center justify-between rounded-md bg-accent-bg px-2.5 py-1.5'
               >
-                <span className='text-xs font-medium text-indigo-800'>
+                <span className='text-xs font-medium text-accent'>
                   {proj.type}
                   {proj.orderBy && (
-                    <span className='ml-1 text-indigo-400 font-normal'>
+                    <span className='ml-1 text-accent font-normal'>
                       (ordered by {proj.orderBy})
                     </span>
                   )}
@@ -190,7 +190,7 @@ const GraphProjectionsDrawer = () => {
                 <button
                   type='button'
                   onClick={() => handleRemoveProjection(proj.type)}
-                  className='ml-2 text-xs text-red-400 hover:text-red-600 font-medium transition-colors'
+                  className='ml-2 text-xs text-danger hover:text-danger font-medium transition-colors'
                   title={`Remove ${proj.type} projection`}
                 >
                   ✕

--- a/packages/sterling/src/components/AppDrawer/graph/state/GraphStateDrawer.tsx
+++ b/packages/sterling/src/components/AppDrawer/graph/state/GraphStateDrawer.tsx
@@ -20,7 +20,7 @@ const GraphStateDrawer = () => {
       {isTrace ? (
         <TimeSection datum={activeDatum} />
       ) : (
-        <div className='p-4 text-sm text-gray-500'>
+        <div className='p-4 text-sm text-ink-muted'>
           <p>Time controls are only available for trace-based instances.</p>
         </div>
       )}

--- a/packages/sterling/src/components/AppDrawer/graph/state/ProjectionSection.tsx
+++ b/packages/sterling/src/components/AppDrawer/graph/state/ProjectionSection.tsx
@@ -180,29 +180,29 @@ const ProjectionSection = ({ datum }: ProjectionSectionProps) => {
   const isMultiTypeMode = projectionData.length > 1;
 
   return (
-    <div className="mx-2 my-2 rounded-lg border border-slate-200 bg-white p-3 shadow-sm">
+    <div className="mx-2 my-2 rounded-lg border border-rule bg-surface p-3 shadow-sm">
       <div className="flex items-center justify-between mb-2">
-        <span className="text-sm font-semibold text-gray-800">Projections</span>
+        <span className="text-sm font-semibold text-ink">Projections</span>
         <div className="flex gap-1">
           {hasCndProjections && (
-            <span className="text-xs text-emerald-600 bg-emerald-50 px-2 py-0.5 rounded">
+            <span className="text-xs text-success bg-success-bg px-2 py-0.5 rounded">
               CND
             </span>
           )}
           {!isMultiTypeMode && (
-            <span className="text-xs text-indigo-600 bg-indigo-50 px-2 py-0.5 rounded">
+            <span className="text-xs text-accent bg-accent-bg px-2 py-0.5 rounded">
               Multi-select
             </span>
           )}
         </div>
       </div>
       {isMultiTypeMode ? (
-        <p className="text-xs text-gray-500 mb-3">
+        <p className="text-xs text-ink-muted mb-3">
           Projecting over multiple types. Select one atom per type.
         </p>
       ) : (
-        <p className="text-xs text-gray-500 mb-3">
-          Projecting over <span className="font-medium text-gray-700">{projectionData[0].typeName}</span>. 
+        <p className="text-xs text-ink-muted mb-3">
+          Projecting over <span className="font-medium text-ink-muted">{projectionData[0].typeName}</span>.
           Click to select, Shift+click to toggle. Multiple selections show separate graphs.
         </p>
       )}
@@ -214,14 +214,14 @@ const ProjectionSection = ({ datum }: ProjectionSectionProps) => {
         return (
           <div key={typeData.typeId} className="mb-3 last:mb-0">
             <div className="flex items-center justify-between mb-1.5">
-              <label className="text-xs font-medium text-gray-700">
+              <label className="text-xs font-medium text-ink-muted">
                 {typeData.typeName}
               </label>
               {!isMultiTypeMode && (
                 <button
                   type="button"
                   onClick={() => handleSelectAll(typeData.typeId, typeData.atoms)}
-                  className="text-xs text-indigo-600 hover:text-indigo-800"
+                  className="text-xs text-accent hover:text-accent"
                 >
                   {allSelected ? 'Select one' : 'Select all'}
                 </button>
@@ -237,9 +237,9 @@ const ProjectionSection = ({ datum }: ProjectionSectionProps) => {
                     onClick={(e) => handleAtomToggle(typeData.typeId, atom.id, e.shiftKey)}
                     className={`
                       px-2.5 py-1 text-xs rounded-md transition-all font-medium
-                      ${isSelected 
-                        ? 'bg-indigo-600 text-white shadow-sm' 
-                        : 'bg-gray-100 text-gray-700 hover:bg-gray-200 border border-gray-200'
+                      ${isSelected
+                        ? 'bg-accent text-on-accent shadow-sm'
+                        : 'bg-surface-sunken text-ink-muted hover:bg-surface-sunken border border-rule'
                       }
                     `}
                   >
@@ -249,7 +249,7 @@ const ProjectionSection = ({ datum }: ProjectionSectionProps) => {
               })}
             </div>
             {!isMultiTypeMode && typeSelections.length > 1 && (
-              <p className="text-xs text-indigo-600 mt-1.5 font-medium">
+              <p className="text-xs text-accent mt-1.5 font-medium">
                 ✓ {typeSelections.length} selected — showing {typeSelections.length} graphs
               </p>
             )}

--- a/packages/sterling/src/components/AppDrawer/graph/state/projections/TimeProjectionListItem.tsx
+++ b/packages/sterling/src/components/AppDrawer/graph/state/projections/TimeProjectionListItem.tsx
@@ -84,7 +84,7 @@ const TimeProjectionsListRow = (props: ItemProps) => {
           />
         </ButtonGroup>
         <MdChevronLeft
-          className='-rotate-90 ml-2 cursor-pointer hover:text-black'
+          className='-rotate-90 ml-2 cursor-pointer hover:text-ink'
           onClick={onToggle}
         />
       </div>
@@ -109,10 +109,10 @@ const TimeProjectionCard = (props: ItemProps) => {
 
   return (
     <div className='m-2 col-span-3 flex flex-col border shadow'>
-      <div className='flex justify-between p-3 bg-slate-50'>
+      <div className='flex justify-between p-3 bg-surface-muted'>
         <div className='text-sm font-bold'>{type}</div>
         <MdChevronLeft
-          className='rotate-90 cursor-pointer hover:text-black'
+          className='rotate-90 cursor-pointer hover:text-ink'
           onClick={onToggle}
         />
       </div>
@@ -177,7 +177,7 @@ const TimeProjectionsListCard = (props: ItemProps) => {
       <div className='flex justify-between pb-3'>
         <div className='text-sm font-bold'>{type}</div>
         <MdChevronLeft
-          className='rotate-90 cursor-pointer hover:text-black'
+          className='rotate-90 cursor-pointer hover:text-ink'
           onClick={onToggle}
         />
       </div>

--- a/packages/sterling/src/components/AppDrawer/graph/state/temporal/TemporalPolicySection.tsx
+++ b/packages/sterling/src/components/AppDrawer/graph/state/temporal/TemporalPolicySection.tsx
@@ -83,7 +83,7 @@ const TemporalPolicySection = ({ datum }: { datum: DatumParsed<any> }) => {
     <div className='px-4 py-3'>
       <label
         htmlFor='temporal-policy-select'
-        className='block text-xs font-semibold uppercase tracking-wide text-gray-500 mb-1'
+        className='block text-xs font-semibold uppercase tracking-wide text-ink-muted mb-1'
       >
         Temporal Policy
       </label>
@@ -91,7 +91,7 @@ const TemporalPolicySection = ({ datum }: { datum: DatumParsed<any> }) => {
         id='temporal-policy-select'
         value={currentPolicy}
         onChange={handleChange}
-        className='w-full rounded border border-gray-300 bg-white px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500'
+        className='w-full rounded border border-rule-strong bg-surface px-3 py-2 text-sm shadow-sm focus:border-accent-border focus:outline-none focus:ring-1 focus:ring-accent'
       >
         {POLICY_OPTIONS.map((opt) => (
           <option key={opt.value} value={opt.value}>
@@ -99,7 +99,7 @@ const TemporalPolicySection = ({ datum }: { datum: DatumParsed<any> }) => {
           </option>
         ))}
       </select>
-      <p className='mt-1 text-xs text-gray-400'>
+      <p className='mt-1 text-xs text-ink-faint'>
         {POLICY_OPTIONS.find((o) => o.value === currentPolicy)?.description}
       </p>
     </div>

--- a/packages/sterling/src/components/AppDrawer/graph/state/time/TimePicker.tsx
+++ b/packages/sterling/src/components/AppDrawer/graph/state/time/TimePicker.tsx
@@ -77,9 +77,9 @@ const TimePicker = ({ datum }: { datum: DatumParsed<any> }) => {
             onClick={toggleMultiSelectMode}
             className={`
               px-2 py-1 text-xs rounded-md transition-all font-medium
-              ${isMultiSelectMode 
-                ? 'bg-blue-600 text-white shadow-sm' 
-                : 'bg-gray-100 text-gray-700 hover:bg-gray-200 border border-gray-200'
+              ${isMultiSelectMode
+                ? 'bg-accent text-on-accent shadow-sm'
+                : 'bg-surface-sunken text-ink-muted hover:bg-surface-sunken border border-rule'
               }
             `}
           >
@@ -91,14 +91,14 @@ const TimePicker = ({ datum }: { datum: DatumParsed<any> }) => {
               <button
                 type="button"
                 onClick={selectFirstLast}
-                className="px-2 py-1 text-xs rounded-md bg-gray-100 text-gray-700 hover:bg-gray-200 border border-gray-200"
+                className="px-2 py-1 text-xs rounded-md bg-surface-sunken text-ink-muted hover:bg-surface-sunken border border-rule"
               >
                 First & Last
               </button>
               <button
                 type="button"
                 onClick={selectAllTimeIndices}
-                className="px-2 py-1 text-xs rounded-md bg-gray-100 text-gray-700 hover:bg-gray-200 border border-gray-200"
+                className="px-2 py-1 text-xs rounded-md bg-surface-sunken text-ink-muted hover:bg-surface-sunken border border-rule"
               >
                 All
               </button>
@@ -110,7 +110,7 @@ const TimePicker = ({ datum }: { datum: DatumParsed<any> }) => {
       {/* Multi-select time step buttons */}
       {isMultiSelectMode && (
         <div className="mb-2">
-          <p className="text-xs text-gray-500 mb-1.5">
+          <p className="text-xs text-ink-muted mb-1.5">
             Click states to compare side-by-side:
           </p>
           <div className="flex flex-wrap gap-1">
@@ -123,9 +123,9 @@ const TimePicker = ({ datum }: { datum: DatumParsed<any> }) => {
                   onClick={() => dispatch(timeIndexToggled({ datum, index: i }))}
                   className={`
                     w-8 h-8 text-xs rounded-md transition-all font-medium
-                    ${isSelected 
-                      ? 'bg-blue-600 text-white shadow-sm' 
-                      : 'bg-gray-100 text-gray-700 hover:bg-gray-200 border border-gray-200'
+                    ${isSelected
+                      ? 'bg-accent text-on-accent shadow-sm'
+                      : 'bg-surface-sunken text-ink-muted hover:bg-surface-sunken border border-rule'
                     }
                   `}
                 >
@@ -135,7 +135,7 @@ const TimePicker = ({ datum }: { datum: DatumParsed<any> }) => {
             })}
           </div>
           {selectedTimeIndices.length > 1 && (
-            <p className="text-xs text-blue-600 mt-1.5 font-medium">
+            <p className="text-xs text-accent mt-1.5 font-medium">
               ✓ {selectedTimeIndices.length} states selected — showing side-by-side comparison
             </p>
           )}

--- a/packages/sterling/src/components/AppDrawer/graph/synthesis/BinaryExampleStep.tsx
+++ b/packages/sterling/src/components/AppDrawer/graph/synthesis/BinaryExampleStep.tsx
@@ -150,7 +150,7 @@ export const BinaryExampleStep = () => {
   return (
     <div className="flex flex-col h-full">
       {/* Instructions */}
-      <div className="p-4 bg-purple-50 border-b border-purple-200">
+      <div className="p-4 bg-accent-bg border-b border-accent-border">
         <Text fontSize="sm" fontWeight="semibold" mb={1} color="purple.900">
           Instance {instanceIndex + 1} of {numInstances} - Binary Selector
         </Text>
@@ -164,7 +164,7 @@ export const BinaryExampleStep = () => {
       {/* Text input for pairs */}
       <div className="p-4 space-y-4">
         <div>
-          <label className="block text-sm font-medium text-gray-700 mb-2">
+          <label className="block text-sm font-medium text-ink-muted mb-2">
             Node Pairs (format: First:Second, comma-separated)
           </label>
           <Input
@@ -187,7 +187,7 @@ export const BinaryExampleStep = () => {
       <div className="flex-1"></div>
 
       {/* Next button */}
-      <div className="p-4 border-t bg-gray-50">
+      <div className="p-4 border-t bg-surface-muted">
         <Button
           w="full"
           colorScheme="purple"

--- a/packages/sterling/src/components/AppDrawer/graph/synthesis/SynthesisDrawer.tsx
+++ b/packages/sterling/src/components/AppDrawer/graph/synthesis/SynthesisDrawer.tsx
@@ -23,44 +23,44 @@ const SynthesisDrawer = () => {
   // If no datum, show a message
   if (!datum) {
     return (
-      <div className="absolute inset-0 flex flex-col items-center justify-center bg-slate-50/90 p-8 text-center">
-        <Icon as={MdScience} boxSize={12} className="mb-4 text-slate-300" />
-        <p className="text-slate-500">Load an instance to start synthesizing selectors.</p>
+      <div className="absolute inset-0 flex flex-col items-center justify-center p-8 text-center" style={{ background: 'var(--ccd-overlay)' }}>
+        <Icon as={MdScience} boxSize={12} className="mb-4 text-ink-faint" />
+        <p className="text-ink-muted">Load an instance to start synthesizing selectors.</p>
       </div>
     );
   }
 
   // Default view - start synthesis button
   return (
-    <div className="absolute inset-0 flex flex-col overflow-y-auto bg-slate-50/90 text-slate-900">
+    <div className="absolute inset-0 flex flex-col overflow-y-auto text-ink" style={{ background: 'var(--ccd-overlay)' }}>
       <div className="flex-1 space-y-4 p-4">
-        <div className="space-y-4 rounded-xl border border-slate-200 bg-white/80 p-6 backdrop-blur shadow-sm">
+        <div className="space-y-4 rounded-xl border border-rule bg-surface p-6 backdrop-blur shadow-sm">
           <div className="flex items-center gap-3">
             <Icon as={MdScience} boxSize={8} className="text-fuchsia-600" />
             <div>
-              <h2 className="text-lg font-semibold text-slate-800">Selector Synthesis</h2>
-              <p className="text-sm text-slate-500">
+              <h2 className="text-lg font-semibold text-ink">Selector Synthesis</h2>
+              <p className="text-sm text-ink-muted">
                 Synthesize selectors from examples
               </p>
             </div>
           </div>
 
-          <p className="text-sm text-slate-600 leading-relaxed">
+          <p className="text-sm text-ink-muted leading-relaxed">
             Use this tool to automatically generate CnD selectors by providing positive 
             and negative examples. Select atoms across multiple instances to define 
             which elements should be matched by the selector.
           </p>
 
           <div className="space-y-3 pt-2">
-            <div className="rounded-lg border border-slate-200 bg-slate-50 p-4">
-              <h3 className="font-medium text-slate-700 mb-2">Selector Types</h3>
-              <ul className="text-sm text-slate-600 space-y-2">
+            <div className="rounded-lg border border-rule bg-surface-muted p-4">
+              <h3 className="font-medium text-ink-muted mb-2">Selector Types</h3>
+              <ul className="text-sm text-ink-muted space-y-2">
                 <li className="flex items-start gap-2">
                   <span className="inline-block w-5 h-5 rounded-full bg-fuchsia-100 text-fuchsia-600 text-xs flex items-center justify-center font-semibold mt-0.5">1</span>
                   <span><strong>Unary:</strong> Select individual atoms (e.g., "all Nodes with value &gt; 5")</span>
                 </li>
                 <li className="flex items-start gap-2">
-                  <span className="inline-block w-5 h-5 rounded-full bg-purple-100 text-purple-600 text-xs flex items-center justify-center font-semibold mt-0.5">2</span>
+                  <span className="inline-block w-5 h-5 rounded-full bg-purple-100 text-accent text-xs flex items-center justify-center font-semibold mt-0.5">2</span>
                   <span><strong>Binary:</strong> Select pairs of atoms/edges (e.g., "all edges where source.value &lt; target.value")</span>
                 </li>
               </ul>
@@ -78,7 +78,7 @@ const SynthesisDrawer = () => {
               <button
                 type="button"
                 onClick={() => dispatch(enterSynthesisMode({ numInstances: 3, selectorType: 'binary' }))}
-                className="inline-flex items-center justify-center gap-2 rounded-lg bg-gradient-to-r from-purple-600 to-indigo-600 px-4 py-3 text-sm font-semibold text-white shadow-md transition hover:from-purple-500 hover:to-indigo-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-purple-500 focus-visible:ring-offset-2 focus-visible:ring-offset-white"
+                className="inline-flex items-center justify-center gap-2 rounded-lg bg-gradient-to-r from-purple-600 to-indigo-600 px-4 py-3 text-sm font-semibold text-white shadow-md transition hover:from-purple-500 hover:to-indigo-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-white"
               >
                 <Icon as={MdScience} />
                 Synthesize Binary Selector

--- a/packages/sterling/src/components/AppDrawer/graph/synthesis/SynthesisExampleStep.tsx
+++ b/packages/sterling/src/components/AppDrawer/graph/synthesis/SynthesisExampleStep.tsx
@@ -115,7 +115,7 @@ export const SynthesisExampleStep = () => {
   return (
     <div className="flex flex-col h-full">
       {/* Instructions */}
-      <div className="p-4 bg-blue-50 border-b border-blue-200">
+      <div className="p-4 bg-accent-bg border-b border-accent-border">
         <Text fontSize="sm" fontWeight="semibold" mb={1} color="blue.900">
           Instance {instanceIndex + 1} of {numInstances}
         </Text>
@@ -128,7 +128,7 @@ export const SynthesisExampleStep = () => {
       {/* Text input for atom IDs */}
       <div className="p-4 space-y-4">
         <div>
-          <label className="block text-sm font-medium text-gray-700 mb-2">
+          <label className="block text-sm font-medium text-ink-muted mb-2">
             Atom IDs (comma-separated)
           </label>
           <Input
@@ -145,7 +145,7 @@ export const SynthesisExampleStep = () => {
       <div className="flex-1"></div>
 
       {/* Next button */}
-      <div className="p-4 border-t bg-gray-50">
+      <div className="p-4 border-t bg-surface-muted">
         <Button
           w="full"
           colorScheme="blue"

--- a/packages/sterling/src/components/AppDrawer/graph/synthesis/SynthesisModePanel.tsx
+++ b/packages/sterling/src/components/AppDrawer/graph/synthesis/SynthesisModePanel.tsx
@@ -233,9 +233,9 @@ const SynthesisModePanel = () => {
   const isResultStep = currentStep > numInstances || result !== null;
 
   return (
-    <div className="absolute inset-0 flex flex-col bg-white">
+    <div className="absolute inset-0 flex flex-col bg-surface">
       {/* Header */}
-      <div className="p-4 border-b bg-blue-50 flex items-center justify-between">
+      <div className="p-4 border-b bg-accent-bg flex items-center justify-between">
         <div className="flex items-center gap-2">
           <Icon as={MdScience} boxSize={6} color="blue.600" />
           <div>
@@ -271,7 +271,7 @@ const SynthesisModePanel = () => {
 
       {/* Footer actions */}
       {!isSetupStep && !isResultStep && (
-        <div className="p-4 border-t bg-gray-50 flex items-center justify-between">
+        <div className="p-4 border-t bg-surface-muted flex items-center justify-between">
           <Button
             size="sm"
             leftIcon={<MdArrowBack />}
@@ -290,7 +290,7 @@ const SynthesisModePanel = () => {
 
       {/* Error display */}
       {error && (
-        <div className="p-4 bg-red-50 border-t border-red-200 text-red-700 text-sm">
+        <div className="p-4 bg-danger-bg border-t border-danger-border text-danger text-sm">
           <strong>Error:</strong> {error}
         </div>
       )}

--- a/packages/sterling/src/components/AppDrawer/graph/theme/GraphLayoutDrawer.tsx
+++ b/packages/sterling/src/components/AppDrawer/graph/theme/GraphLayoutDrawer.tsx
@@ -250,20 +250,20 @@ const GraphLayoutDrawer = () => {
   }
 
   return (
-    <div className="absolute inset-0 flex flex-col overflow-y-auto bg-slate-50/90 text-slate-900">
+    <div className="absolute inset-0 flex flex-col overflow-y-auto text-ink" style={{ background: 'var(--ccd-overlay)' }}>
       <div className="flex-1 space-y-3 p-3">
         {/* Actions */}
         <div className="flex gap-2">
           <button
             type="button"
             onClick={applyLayout}
-            className="flex-1 rounded-lg bg-indigo-600 px-4 py-2.5 text-sm font-medium text-white shadow-sm transition hover:bg-indigo-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2"
+            className="flex-1 rounded-lg bg-accent px-4 py-2.5 text-sm font-medium text-on-accent shadow-sm transition hover:bg-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2"
           >
             Apply Layout
           </button>
           
           <label className="group relative flex-1 cursor-pointer">
-            <div className="flex items-center justify-center gap-2 rounded-lg border-2 border-dashed border-slate-300 bg-white px-4 py-2.5 text-sm font-medium text-slate-600 transition hover:border-indigo-400 hover:text-indigo-600">
+            <div className="flex items-center justify-center gap-2 rounded-lg border-2 border-dashed border-rule-strong bg-surface px-4 py-2.5 text-sm font-medium text-ink-muted transition hover:border-accent-border hover:text-accent">
               <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-8l-4-4m0 0L8 8m4-4v12" />
               </svg>
@@ -279,11 +279,11 @@ const GraphLayoutDrawer = () => {
         </div>
 
         {/* Editor */}
-        <div className="rounded-lg border border-slate-200 bg-white shadow-sm p-3">
+        <div className="rounded-lg border border-rule bg-surface shadow-sm p-3">
           <div
             id="cnd-editor-mount"
             ref={cndEditorRef}
-            className="min-h-[360px] overflow-hidden rounded-lg border border-slate-200 bg-slate-50"
+            className="min-h-[360px] overflow-hidden rounded-lg border border-rule bg-surface-muted"
           />
         </div>
       </div>

--- a/packages/sterling/src/components/AppDrawer/script/variables/Row.tsx
+++ b/packages/sterling/src/components/AppDrawer/script/variables/Row.tsx
@@ -5,13 +5,13 @@ const Row = (props: PropsWithChildren<any>) => (
 );
 
 const RowType = (props: PropsWithChildren<any>) => (
-  <div className='px-4 py-0.5 prose text-xs group-hover:bg-slate-100'>
+  <div className='px-4 py-0.5 prose text-xs group-hover:bg-surface-sunken'>
     {props.children}
   </div>
 );
 
 const RowVariable = (props: PropsWithChildren<any>) => (
-  <div className='px-4 py-0.5 text-xs font-mono group-hover:bg-slate-100'>
+  <div className='px-4 py-0.5 text-xs font-mono group-hover:bg-surface-sunken'>
     {props.children}
   </div>
 );

--- a/packages/sterling/src/components/AppMiniMap/AppMiniMap.tsx
+++ b/packages/sterling/src/components/AppMiniMap/AppMiniMap.tsx
@@ -10,12 +10,11 @@ const AppMiniMap = () => {
       transform='translate(-50%)'
       width='350px'
       height='50px'
-      backgroundColor='white'
       shadow='base'
       borderRadius='base'
       border='1px'
-      borderColor='gray.400'
-      bg='white'
+      borderColor='var(--ccd-rule-strong)'
+      bg='var(--ccd-minimap-bg)'
     >
       <MiniMap
         numStates={5}

--- a/packages/sterling/src/components/AppNavBar/AppNavBar.tsx
+++ b/packages/sterling/src/components/AppNavBar/AppNavBar.tsx
@@ -1,6 +1,7 @@
 import { Logo, NavBar } from '@/sterling-ui';
 import { Divider, Spacer } from '@chakra-ui/react';
 import { ViewButtons } from './ViewButtons';
+import { ThemeToggle } from './ThemeToggle';
 
 const AppNavBar = () => {
   return (
@@ -9,6 +10,8 @@ const AppNavBar = () => {
       <Divider orientation='vertical' mx={2} />
       <Spacer />
       <ViewButtons />
+      <Divider orientation='vertical' mx={2} />
+      <ThemeToggle />
     </NavBar>
   );
 };

--- a/packages/sterling/src/components/AppNavBar/ThemeToggle.tsx
+++ b/packages/sterling/src/components/AppNavBar/ThemeToggle.tsx
@@ -1,0 +1,29 @@
+import { IconButton } from '@chakra-ui/react';
+import { MoonIcon, SunIcon } from '@chakra-ui/icons';
+import { useSterlingDispatch, useSterlingSelector } from '../../state/hooks';
+import { selectColorMode } from '../../state/selectors';
+import { colorModeToggled } from '../../state/ui/uiSlice';
+
+/**
+ * The in-app light/dark switch (available on every view). Dispatches the
+ * toggle; the DOM `data-theme`, persistence, and graph sync follow from the
+ * store change.
+ */
+const ThemeToggle = () => {
+  const dispatch = useSterlingDispatch();
+  const colorMode = useSterlingSelector(selectColorMode);
+  const isDark = colorMode === 'dark';
+  const label = isDark ? 'Switch to light mode' : 'Switch to dark mode';
+  return (
+    <IconButton
+      aria-label={label}
+      title={label}
+      icon={isDark ? <SunIcon /> : <MoonIcon />}
+      onClick={() => dispatch(colorModeToggled())}
+      size='sm'
+      variant='ghost'
+    />
+  );
+};
+
+export { ThemeToggle };

--- a/packages/sterling/src/components/DatumControls/DatumControls.tsx
+++ b/packages/sterling/src/components/DatumControls/DatumControls.tsx
@@ -1,6 +1,6 @@
 const DatumControls = () => {
   return (
-    <div className='absolute top-0 right-0 left-0 h-[30px] bg-slate-100' />
+    <div className='absolute top-0 right-0 left-0 h-[30px] bg-surface-sunken' />
   );
 };
 

--- a/packages/sterling/src/components/EditView/EditView.tsx
+++ b/packages/sterling/src/components/EditView/EditView.tsx
@@ -126,7 +126,7 @@ const EditView = () => {
         <Pane>
           <PaneHeader className='border-b'>
             <div className='w-full flex items-center px-2 space-x-2'>
-              <PaneTitle className='text-gray-400'>Edit</PaneTitle>
+              <PaneTitle className='text-ink-faint'>Edit</PaneTitle>
               {datum && (
                 <PaneTitle>{datum.parsed.command}</PaneTitle>
               )}
@@ -135,7 +135,7 @@ const EditView = () => {
                 <button
                   type="button"
                   onClick={handleLoadFromInstance}
-                  className="px-3 py-1 text-xs font-medium rounded border border-slate-300 bg-white text-slate-600 hover:bg-slate-50 hover:border-slate-400 transition"
+                  className="px-3 py-1 text-xs font-medium rounded border border-rule-strong bg-surface text-ink-muted hover:bg-surface-muted hover:border-rule-strong transition"
                 >
                   Load from Instance
                 </button>
@@ -143,25 +143,25 @@ const EditView = () => {
               <button
                 type="button"
                 onClick={handleExport}
-                className="px-3 py-1 text-xs font-medium rounded bg-indigo-600 text-white hover:bg-indigo-500 transition"
+                className="px-3 py-1 text-xs font-medium rounded bg-accent text-on-accent hover:bg-accent transition"
               >
                 Export as inst
               </button>
               {exportFeedback?.status === 'success' && (
-                <span className="text-xs text-green-600 font-medium">
+                <span className="text-xs text-success font-medium">
                   {exportFeedback.message}
                 </span>
               )}
             </div>
           </PaneHeader>
-          <div className="px-3 py-1.5 bg-amber-50 border-b border-amber-200 text-amber-700 text-xs">
+          <div className="px-3 py-1.5 bg-warning-bg border-b border-warning-border text-warning text-xs">
             Experimental feature — Edit mode is under active development.
           </div>
           {exportFeedback && exportFeedback.status !== 'success' && (
             <div className={`px-3 py-2 border-b text-xs ${
               exportFeedback.status === 'error'
-                ? 'bg-red-50 border-red-200 text-red-700'
-                : 'bg-amber-50 border-amber-200 text-amber-700'
+                ? 'bg-danger-bg border-danger-border text-danger'
+                : 'bg-warning-bg border-warning-border text-warning'
             }`}>
               <div className="flex items-center justify-between">
                 <span className="font-medium">{exportFeedback.message}</span>
@@ -188,7 +188,7 @@ const EditView = () => {
                 <ul className="mt-1.5 space-y-0.5 list-disc list-inside">
                   {exportFeedback.issues.map((issue, idx) => (
                     <li key={idx}>
-                      <span className={issue.severity === 'error' ? 'text-red-600' : 'text-amber-600'}>
+                      <span className={issue.severity === 'error' ? 'text-danger' : 'text-warning'}>
                         {issue.message}
                       </span>
                     </li>

--- a/packages/sterling/src/components/EditView/SpyTialEditGraph.tsx
+++ b/packages/sterling/src/components/EditView/SpyTialEditGraph.tsx
@@ -4,12 +4,15 @@ import {
   useCallback,
   useEffect,
   useImperativeHandle,
+  useLayoutEffect,
   useRef,
   useState,
 } from 'react';
 import { parseCndFile, type CndProjection, type SequencePolicyName } from '../../utils/cndPreParser';
 import { getSpytialCore, hasSpytialCore } from '../../utils/spytialCore';
 import type { LayoutState } from '../GraphView/SpyTialGraph';
+import { useSterlingSelector } from '../../state/hooks';
+import { selectColorMode } from '../../state/selectors';
 
 // Extend HTMLElementTagNameMap for the structured-input-graph custom element
 declare global {
@@ -24,6 +27,8 @@ declare global {
       getLayoutState?: () => LayoutState;
       addToolbarControl?: (element: HTMLElement) => void;
       clear?: () => void;
+      /** Switch the graph's internal theme (inherited from WebColaCnDGraph, spytial-core >= 2.8.0). */
+      setTheme?: (mode: 'light' | 'dark') => void;
       setDataInstance?: (instance: any) => void;
       getDataInstance?: () => any;
       getCurrentConstraintError?: () => any;
@@ -78,6 +83,9 @@ const SpyTialEditGraph = forwardRef<SpyTialEditGraphHandle, SpyTialEditGraphProp
     graphElementRef: externalGraphRef,
   } = props;
 
+  const colorMode = useSterlingSelector(selectColorMode);
+  const colorModeRef = useRef(colorMode);
+  colorModeRef.current = colorMode;
   const graphContainerRef = useRef<HTMLDivElement>(null);
   const graphElementRef = useRef<HTMLElementTagNameMap['structured-input-graph'] | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -155,6 +163,9 @@ const SpyTialEditGraph = forwardRef<SpyTialEditGraphHandle, SpyTialEditGraphProp
     setError(null);
 
     try {
+      // Apply the active theme before (re)rendering so JS-driven fills follow.
+      el.setTheme?.(colorModeRef.current);
+
       // 1. Apply the CnD spec. Use the public Promise-returning method so
       // we can await pipeline initialization. Older spytial-core versions
       // only expose the attribute path; fall back with a warning.
@@ -207,6 +218,9 @@ const SpyTialEditGraph = forwardRef<SpyTialEditGraphHandle, SpyTialEditGraphProp
       setError(err?.message ?? 'Failed to load editor');
       setIsLoading(false);
     }
+    // colorMode is intentionally NOT a dependency: theme switches re-tint in
+    // place via setTheme (effect below) — a full bootstrap here races
+    // spytial-core's WebCola ticks against nulled selections.
   }, [cndSpec, datum?.id, datum?.data, timeIndex, isCndCoreReady]);
 
   // Run bootstrap when its inputs change. We deliberately key on datum.id
@@ -219,6 +233,11 @@ const SpyTialEditGraph = forwardRef<SpyTialEditGraphHandle, SpyTialEditGraphProp
     runBootstrap(false);
   }, [runBootstrap, isCndCoreReady, graphMounted]);
 
+  // Theme switches re-tint the live graph in place (no re-bootstrap).
+  useEffect(() => {
+    graphElementRef.current?.setTheme?.(colorMode);
+  }, [colorMode]);
+
   useImperativeHandle(ref, () => ({
     reloadFromInstance: async () => {
       lastLoadedKeyRef.current = null;
@@ -226,8 +245,11 @@ const SpyTialEditGraph = forwardRef<SpyTialEditGraphHandle, SpyTialEditGraphProp
     },
   }), [runBootstrap]);
 
-  // Create and mount the structured-input-graph element once
-  useEffect(() => {
+  // Create and mount the structured-input-graph element once.
+  // useLayoutEffect so the cleanup detaches the element synchronously, ahead of
+  // React removing the host DOM; the try/catch contains spytial-core's dispose
+  // throw (getPointAtLength on an empty edge path) so it can't break unmount.
+  useLayoutEffect(() => {
     if (!graphContainerRef.current || isInitializedRef.current) return;
 
     const graphElement = document.createElement('structured-input-graph') as HTMLElementTagNameMap['structured-input-graph'];
@@ -235,6 +257,7 @@ const SpyTialEditGraph = forwardRef<SpyTialEditGraphHandle, SpyTialEditGraphProp
     graphElement.setAttribute('layoutFormat', 'default');
     graphElement.setAttribute('show-export', 'false'); // We handle export ourselves
     graphElement.setAttribute('aria-label', 'Interactive graph editor');
+    graphElement.setAttribute('theme', colorModeRef.current);
     graphElement.style.cssText = `
       width: 100%;
       height: 100%;
@@ -321,11 +344,15 @@ const SpyTialEditGraph = forwardRef<SpyTialEditGraphHandle, SpyTialEditGraphProp
         graphElementRef.current.removeEventListener('layout-generation-error', handleLayoutGenerationError as EventListener);
         graphElementRef.current.removeEventListener('constraints-satisfied', handleConstraintsSatisfied as EventListener);
 
-        if (graphElementRef.current.clear) {
-          graphElementRef.current.clear();
+        try {
+          graphElementRef.current.clear?.();
+        } catch {
+          /* ignore */
         }
-        if (graphContainerRef.current && graphElementRef.current.parentNode === graphContainerRef.current) {
-          graphContainerRef.current.removeChild(graphElementRef.current);
+        try {
+          graphElementRef.current.remove();
+        } catch {
+          /* ignore spytial-core dispose throw */
         }
       }
       graphElementRef.current = null;
@@ -344,7 +371,7 @@ const SpyTialEditGraph = forwardRef<SpyTialEditGraphHandle, SpyTialEditGraphProp
     <div
       className="absolute inset-0 flex flex-col"
       style={{
-        background: 'white',
+        background: 'var(--ccd-surface)',
         overflow: 'hidden'
       }}
     >
@@ -362,15 +389,15 @@ const SpyTialEditGraph = forwardRef<SpyTialEditGraphHandle, SpyTialEditGraphProp
         // initializes — prevents add/delete from triggering the silent
         // no-op render path before layoutInstance/currentLayout exist.
         <div
-          className="absolute inset-0 flex items-center justify-center bg-white bg-opacity-75"
-          style={{ zIndex: 10, pointerEvents: 'auto' }}
+          className="absolute inset-0 flex items-center justify-center"
+          style={{ zIndex: 10, pointerEvents: 'auto', background: 'var(--ccd-overlay)' }}
         >
-          <div className="text-gray-600">Loading editor...</div>
+          <div className="text-ink-muted">Loading editor...</div>
         </div>
       )}
       {error && (
         <div
-          className="absolute bottom-0 left-0 right-0 p-4 bg-red-100 border-t border-red-300 text-red-700"
+          className="absolute bottom-0 left-0 right-0 p-4 bg-danger-bg border-t border-danger-border text-danger"
           style={{ zIndex: 20 }}
         >
           <strong>Error:</strong> {error}

--- a/packages/sterling/src/components/GraphView/GraphViewHeader.tsx
+++ b/packages/sterling/src/components/GraphView/GraphViewHeader.tsx
@@ -14,7 +14,7 @@ const GraphViewHeader = (props: GraphViewHeaderProps) => {
 
   return (
     <div className='w-full flex item-center space-x-2 px-2'>
-      <PaneTitle className='text-gray-400'>ID: {id}</PaneTitle>
+      <PaneTitle className='text-ink-faint'>ID: {id}</PaneTitle>
       <PaneTitle>{command}</PaneTitle>
       <div className='grow' />
       {buttons &&

--- a/packages/sterling/src/components/GraphView/MultiProjectionGraph.tsx
+++ b/packages/sterling/src/components/GraphView/MultiProjectionGraph.tsx
@@ -1,8 +1,10 @@
 import { DatumParsed } from '@/sterling-connection';
-import { useCallback, useEffect, useRef, useState, useMemo } from 'react';
+import { useCallback, useEffect, useLayoutEffect, useRef, useState, useMemo } from 'react';
 import type { LayoutState, TransformInfo, NodePositionHint } from './SpyTialGraph';
 import { parseCndFile, CndProjection, SequencePolicyName } from '../../utils/cndPreParser';
 import { getSpytialCore, hasSpytialCore } from '../../utils/spytialCore';
+import { useSterlingSelector } from '../../state/hooks';
+import { selectColorMode } from '../../state/selectors';
 
 // Use the Window type declaration from SpyTialGraph.tsx - no need to re-declare
 
@@ -59,7 +61,10 @@ interface SingleProjectionPaneProps {
  */
 const SingleProjectionPane = (props: SingleProjectionPaneProps) => {
   const { datum, cndSpec, timeIndex, projectionType, atomId, atomLabel, index } = props;
-  
+
+  const colorMode = useSterlingSelector(selectColorMode);
+  const colorModeRef = useRef(colorMode);
+  colorModeRef.current = colorMode;
   const graphContainerRef = useRef<HTMLDivElement>(null);
   const graphElementRef = useRef<HTMLElementTagNameMap['webcola-cnd-graph'] | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -181,6 +186,7 @@ const SingleProjectionPane = (props: SingleProjectionPaneProps) => {
         if (graphElementRef.current.clear) {
           graphElementRef.current.clear();
         }
+        graphElementRef.current.setTheme?.(colorModeRef.current);
         await graphElementRef.current.renderLayout(layoutResult.layout);
       }
 
@@ -190,16 +196,23 @@ const SingleProjectionPane = (props: SingleProjectionPaneProps) => {
       setError(`Error: ${err.message}`);
       setIsLoading(false);
     }
+    // colorMode is intentionally NOT a dependency: theme switches re-tint in
+    // place via setTheme (effect below) — a full clear()+renderLayout here
+    // races spytial-core's WebCola ticks against nulled selections.
   }, [datum.data, datum.id, cndSpec, timeIndex, projectionType, atomId, atomLabel]);
 
-  // Create and mount the webcola-cnd-graph element once
-  useEffect(() => {
+  // Create and mount the webcola-cnd-graph element once.
+  // useLayoutEffect so the cleanup detaches the element synchronously, ahead of
+  // React removing the host DOM; the try/catch contains spytial-core's dispose
+  // throw (getPointAtLength on an empty edge path) so it can't break unmount.
+  useLayoutEffect(() => {
     if (!graphContainerRef.current || isInitializedRef.current) return;
 
     const graphElement = document.createElement('webcola-cnd-graph') as HTMLElementTagNameMap['webcola-cnd-graph'];
     graphElement.id = `spytial-graph-projection-${index}`;
     graphElement.setAttribute('layoutFormat', 'default');
     graphElement.setAttribute('aria-label', `Graph visualization for ${atomLabel}`);
+    graphElement.setAttribute('theme', colorModeRef.current);
     graphElement.style.cssText = `
       width: 100%;
       height: 100%;
@@ -213,11 +226,15 @@ const SingleProjectionPane = (props: SingleProjectionPaneProps) => {
 
     return () => {
       if (graphElementRef.current) {
-        if (graphElementRef.current.clear) {
-          graphElementRef.current.clear();
+        try {
+          graphElementRef.current.clear?.();
+        } catch {
+          /* ignore */
         }
-        if (graphContainerRef.current && graphElementRef.current.parentNode === graphContainerRef.current) {
-          graphContainerRef.current.removeChild(graphElementRef.current);
+        try {
+          graphElementRef.current.remove();
+        } catch {
+          /* ignore spytial-core dispose throw */
         }
       }
       graphElementRef.current = null;
@@ -233,36 +250,41 @@ const SingleProjectionPane = (props: SingleProjectionPaneProps) => {
     }
   }, [datum.data, cndSpec, timeIndex, loadGraph]);
 
+  // Theme switches re-tint the live graph in place (no re-layout).
+  useEffect(() => {
+    graphElementRef.current?.setTheme?.(colorMode);
+  }, [colorMode]);
+
   return (
-    <div className="relative flex flex-col border border-gray-300 rounded-lg overflow-hidden bg-white shadow-sm">
+    <div className="relative flex flex-col border border-rule-strong rounded-lg overflow-hidden bg-surface shadow-sm">
       {/* Header with projection label */}
-      <div className="px-3 py-2 bg-gray-100 border-b border-gray-200">
-        <span className="font-medium text-sm text-gray-700">{atomLabel}</span>
+      <div className="px-3 py-2 bg-surface-muted border-b border-rule">
+        <span className="font-medium text-sm text-ink-muted">{atomLabel}</span>
       </div>
-      
+
       {/* Graph container */}
-      <div 
+      <div
         ref={graphContainerRef}
         className="flex-1"
-        style={{ 
+        style={{
           minHeight: '250px',
-          background: 'white'
+          background: 'var(--ccd-surface)'
         }}
       />
-      
+
       {/* Loading overlay */}
       {isLoading && (
-        <div 
-          className="absolute inset-0 flex items-center justify-center bg-white bg-opacity-75"
-          style={{ zIndex: 10, pointerEvents: 'none' }}
+        <div
+          className="absolute inset-0 flex items-center justify-center"
+          style={{ zIndex: 10, pointerEvents: 'none', background: 'var(--ccd-overlay)' }}
         >
-          <div className="text-gray-600 text-sm">Loading...</div>
+          <div className="text-ink-muted text-sm">Loading...</div>
         </div>
       )}
       
       {/* Error display */}
       {error && (
-        <div className="px-3 py-2 bg-red-50 border-t border-red-200 text-red-600 text-xs">
+        <div className="px-3 py-2 bg-danger-bg border-t border-danger-border text-danger text-xs">
           {error}
         </div>
       )}
@@ -391,7 +413,7 @@ const MultiProjectionGraph = (props: MultiProjectionGraphProps) => {
   if (error) {
     return (
       <div className="flex items-center justify-center h-full p-4">
-        <div className="text-red-600 bg-red-50 p-4 rounded-lg">
+        <div className="text-danger bg-danger-bg p-4 rounded-lg">
           <strong>Error:</strong> {error}
         </div>
       </div>
@@ -401,7 +423,7 @@ const MultiProjectionGraph = (props: MultiProjectionGraphProps) => {
   if (!isCndCoreReady) {
     return (
       <div className="flex items-center justify-center h-full">
-        <div className="text-gray-600">Loading CnD Core...</div>
+        <div className="text-ink-muted">Loading CnD Core...</div>
       </div>
     );
   }
@@ -409,7 +431,7 @@ const MultiProjectionGraph = (props: MultiProjectionGraphProps) => {
   if (atomsToRender.length === 0) {
     return (
       <div className="flex items-center justify-center h-full p-4">
-        <div className="text-gray-600 bg-gray-50 p-4 rounded-lg">
+        <div className="text-ink-muted bg-surface-muted p-4 rounded-lg">
           No atoms selected for projection type "{projectionType}".
         </div>
       </div>
@@ -424,13 +446,13 @@ const MultiProjectionGraph = (props: MultiProjectionGraphProps) => {
 
   return (
     <div 
-      className="absolute inset-0 overflow-auto bg-gray-100 p-4"
+      className="absolute inset-0 overflow-auto bg-surface-sunken p-4"
     >
       <div className="mb-4 px-2">
-        <h2 className="text-lg font-semibold text-gray-800">
+        <h2 className="text-lg font-semibold text-ink">
           Projections over {displayTypeName}
         </h2>
-        <p className="text-sm text-gray-600">
+        <p className="text-sm text-ink-muted">
           Showing {atomsToRender.length} selected projection{atomsToRender.length !== 1 ? 's' : ''}
         </p>
       </div>

--- a/packages/sterling/src/components/GraphView/MultiTemporalGraph.tsx
+++ b/packages/sterling/src/components/GraphView/MultiTemporalGraph.tsx
@@ -1,7 +1,9 @@
 import { DatumParsed } from '@/sterling-connection';
-import { useCallback, useEffect, useRef, useState, useMemo } from 'react';
+import { useCallback, useEffect, useLayoutEffect, useRef, useState, useMemo } from 'react';
 import { parseCndFile, SequencePolicyName } from '../../utils/cndPreParser';
 import { getSpytialCore, hasSpytialCore } from '../../utils/spytialCore';
+import { useSterlingSelector } from '../../state/hooks';
+import { selectColorMode } from '../../state/selectors';
 
 /**
  * The signature label that Forge uses to indicate no more instances are available.
@@ -50,7 +52,10 @@ interface SingleTemporalPaneProps {
  */
 const SingleTemporalPane = (props: SingleTemporalPaneProps) => {
   const { datum, cndSpec, timeIndex, traceLength, index, sequencePolicyName = 'stability' } = props;
-  
+
+  const colorMode = useSterlingSelector(selectColorMode);
+  const colorModeRef = useRef(colorMode);
+  colorModeRef.current = colorMode;
   const graphContainerRef = useRef<HTMLDivElement>(null);
   const graphElementRef = useRef<HTMLElementTagNameMap['webcola-cnd-graph'] | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -139,6 +144,7 @@ const SingleTemporalPane = (props: SingleTemporalPaneProps) => {
         if (graphElementRef.current.clear) {
           graphElementRef.current.clear();
         }
+        graphElementRef.current.setTheme?.(colorModeRef.current);
         await graphElementRef.current.renderLayout(layoutResult.layout);
       }
 
@@ -148,16 +154,23 @@ const SingleTemporalPane = (props: SingleTemporalPaneProps) => {
       setError(`Error: ${err.message}`);
       setIsLoading(false);
     }
+    // colorMode is intentionally NOT a dependency: theme switches re-tint in
+    // place via setTheme (effect below) — a full clear()+renderLayout here
+    // races spytial-core's WebCola ticks against nulled selections.
   }, [datum.data, datum.id, cndSpec, timeIndex, sequencePolicyName]);
 
-  // Create and mount the webcola-cnd-graph element once
-  useEffect(() => {
+  // Create and mount the webcola-cnd-graph element once.
+  // useLayoutEffect so the cleanup detaches the element synchronously, ahead of
+  // React removing the host DOM; the try/catch contains spytial-core's dispose
+  // throw (getPointAtLength on an empty edge path) so it can't break unmount.
+  useLayoutEffect(() => {
     if (!graphContainerRef.current || isInitializedRef.current) return;
 
     const graphElement = document.createElement('webcola-cnd-graph') as HTMLElementTagNameMap['webcola-cnd-graph'];
     graphElement.id = `spytial-graph-temporal-${index}`;
     graphElement.setAttribute('layoutFormat', 'default');
     graphElement.setAttribute('aria-label', `Graph visualization for time step ${timeIndex + 1}`);
+    graphElement.setAttribute('theme', colorModeRef.current);
     graphElement.style.cssText = `
       width: 100%;
       height: 100%;
@@ -171,11 +184,15 @@ const SingleTemporalPane = (props: SingleTemporalPaneProps) => {
 
     return () => {
       if (graphElementRef.current) {
-        if (graphElementRef.current.clear) {
-          graphElementRef.current.clear();
+        try {
+          graphElementRef.current.clear?.();
+        } catch {
+          /* ignore */
         }
-        if (graphContainerRef.current && graphElementRef.current.parentNode === graphContainerRef.current) {
-          graphContainerRef.current.removeChild(graphElementRef.current);
+        try {
+          graphElementRef.current.remove();
+        } catch {
+          /* ignore spytial-core dispose throw */
         }
       }
       graphElementRef.current = null;
@@ -191,38 +208,43 @@ const SingleTemporalPane = (props: SingleTemporalPaneProps) => {
     }
   }, [datum.data, cndSpec, timeIndex, loadGraph]);
 
+  // Theme switches re-tint the live graph in place (no re-layout).
+  useEffect(() => {
+    graphElementRef.current?.setTheme?.(colorMode);
+  }, [colorMode]);
+
   return (
-    <div className="relative flex flex-col border border-gray-300 rounded-lg overflow-hidden bg-white shadow-sm">
+    <div className="relative flex flex-col border border-rule-strong rounded-lg overflow-hidden bg-surface shadow-sm">
       {/* Header with time step label */}
-      <div className="px-3 py-2 bg-blue-50 border-b border-blue-200">
-        <span className="font-medium text-sm text-blue-800">
+      <div className="px-3 py-2 bg-info-bg border-b border-info-border">
+        <span className="font-medium text-sm text-info">
           State {timeIndex + 1} of {traceLength}
         </span>
       </div>
-      
+
       {/* Graph container */}
-      <div 
+      <div
         ref={graphContainerRef}
         className="flex-1"
-        style={{ 
+        style={{
           minHeight: '250px',
-          background: 'white'
+          background: 'var(--ccd-surface)'
         }}
       />
-      
+
       {/* Loading overlay */}
       {isLoading && (
-        <div 
-          className="absolute inset-0 flex items-center justify-center bg-white bg-opacity-75"
-          style={{ zIndex: 10, pointerEvents: 'none' }}
+        <div
+          className="absolute inset-0 flex items-center justify-center"
+          style={{ zIndex: 10, pointerEvents: 'none', background: 'var(--ccd-overlay)' }}
         >
-          <div className="text-gray-600 text-sm">Loading...</div>
+          <div className="text-ink-muted text-sm">Loading...</div>
         </div>
       )}
-      
+
       {/* Error display */}
       {error && (
-        <div className="px-3 py-2 bg-red-50 border-t border-red-200 text-red-600 text-xs">
+        <div className="px-3 py-2 bg-danger-bg border-t border-danger-border text-danger text-xs">
           {error}
         </div>
       )}
@@ -280,7 +302,7 @@ const MultiTemporalGraph = (props: MultiTemporalGraphProps) => {
   if (error) {
     return (
       <div className="flex items-center justify-center h-full p-4">
-        <div className="text-red-600 bg-red-50 p-4 rounded-lg">
+        <div className="text-danger bg-danger-bg p-4 rounded-lg">
           <strong>Error:</strong> {error}
         </div>
       </div>
@@ -290,7 +312,7 @@ const MultiTemporalGraph = (props: MultiTemporalGraphProps) => {
   if (!isCndCoreReady) {
     return (
       <div className="flex items-center justify-center h-full">
-        <div className="text-gray-600">Loading CnD Core...</div>
+        <div className="text-ink-muted">Loading CnD Core...</div>
       </div>
     );
   }
@@ -298,7 +320,7 @@ const MultiTemporalGraph = (props: MultiTemporalGraphProps) => {
   if (selectedTimeIndices.length === 0) {
     return (
       <div className="flex items-center justify-center h-full p-4">
-        <div className="text-gray-600 bg-gray-50 p-4 rounded-lg">
+        <div className="text-ink-muted bg-surface-muted p-4 rounded-lg">
           No time steps selected.
         </div>
       </div>
@@ -306,12 +328,12 @@ const MultiTemporalGraph = (props: MultiTemporalGraphProps) => {
   }
 
   return (
-    <div className="absolute inset-0 overflow-auto bg-gray-100 p-4">
+    <div className="absolute inset-0 overflow-auto bg-surface-sunken p-4">
       <div className="mb-4 px-2">
-        <h2 className="text-lg font-semibold text-gray-800">
+        <h2 className="text-lg font-semibold text-ink">
           Temporal Comparison
         </h2>
-        <p className="text-sm text-gray-600">
+        <p className="text-sm text-ink-muted">
           Showing {selectedTimeIndices.length} time step{selectedTimeIndices.length !== 1 ? 's' : ''} of {traceLength}
         </p>
       </div>

--- a/packages/sterling/src/components/GraphView/SpyTialGraph.tsx
+++ b/packages/sterling/src/components/GraphView/SpyTialGraph.tsx
@@ -1,7 +1,11 @@
 import { DatumParsed } from '@/sterling-connection';
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
 import { parseCndFile, type CndProjection, type SequencePolicyName } from '../../utils/cndPreParser';
 import { getSpytialCore, hasSpytialCore } from '../../utils/spytialCore';
+import { useSterlingDispatch, useSterlingSelector } from '../../state/hooks';
+import { selectColorMode } from '../../state/selectors';
+import { colorModeSet } from '../../state/ui/uiSlice';
+import { isColorMode } from '../../theme/colorMode';
 
 /**
  * The signature label that Forge uses to indicate no more instances are available.
@@ -58,6 +62,10 @@ declare global {
       getLayoutState?: () => LayoutState;
       addToolbarControl?: (element: HTMLElement) => void;
       clear?: () => void;
+      // Theme API (spytial-core >= 2.8.0). setTheme re-tints a live graph with
+      // no re-render; the element also fires a 'theme-changed' event when the
+      // user picks a theme in its built-in Mode dropdown.
+      setTheme?: (name: string, overrides?: Record<string, string>, nodeColors?: Record<string, number>) => void;
       // Node highlighting for synthesis mode
       clearNodeHighlights?: () => void;
       highlightNodes?: (nodeIds: string[], color?: string) => boolean;
@@ -101,6 +109,12 @@ const SpyTialGraph = (props: SpyTialGraphProps) => {
     sequencePolicyName = 'ignore_history',
     projectionSelections = {}
   } = props;
+  // App color mode, synced bidirectionally with the graph's own theme.
+  const dispatch = useSterlingDispatch();
+  const colorMode = useSterlingSelector(selectColorMode);
+  const colorModeRef = useRef(colorMode);
+  colorModeRef.current = colorMode;
+
   // Separate ref for the graph container - this div is NOT managed by React's children
   const graphContainerRef = useRef<HTMLDivElement>(null);
   const graphElementRef = useRef<HTMLElementTagNameMap['webcola-cnd-graph'] | null>(null);
@@ -414,8 +428,12 @@ const SpyTialGraph = (props: SpyTialGraphProps) => {
     }
   }, [datum.data, datum.id, cndSpec, timeIndex, priorState]);
 
-  // Create and mount the webcola-cnd-graph element once
-  useEffect(() => {
+  // Create and mount the webcola-cnd-graph element once.
+  // useLayoutEffect (not useEffect) so the cleanup runs synchronously during the
+  // commit phase — ahead of React removing the host DOM — letting us detach the
+  // element ourselves and swallow any teardown error from the graph's
+  // disconnectedCallback (spytial-core can throw on an empty edge path).
+  useLayoutEffect(() => {
     if (!graphContainerRef.current || isInitializedRef.current) return;
 
     // Create the webcola-cnd-graph custom element
@@ -424,6 +442,9 @@ const SpyTialGraph = (props: SpyTialGraphProps) => {
     graphElement.setAttribute('layoutFormat', 'default');
     graphElement.setAttribute('transition-mode', 'morph');
     graphElement.setAttribute('aria-label', 'Interactive graph visualization');
+    // Start the graph on the app's current theme (declarative; applied by the
+    // element's attributeChangedCallback).
+    graphElement.setAttribute('theme', colorModeRef.current);
     graphElement.style.cssText = `
       width: 100%;
       height: 100%;
@@ -468,9 +489,18 @@ const SpyTialGraph = (props: SpyTialGraphProps) => {
       }
     };
 
+    // Graph -> app sync: when the user picks a theme in the graph's built-in
+    // Mode dropdown, follow it for the app chrome. (setTheme() does NOT fire
+    // this event, so app -> graph pushes never loop back.)
+    const handleThemeChanged = (e: CustomEvent) => {
+      const name = e?.detail?.theme;
+      if (isColorMode(name)) dispatch(colorModeSet(name));
+    };
+
     graphElement.addEventListener('layout-complete', handleLayoutComplete as EventListener);
     graphElement.addEventListener('node-drag-end', handleNodeDragEnd as EventListener);
     graphElement.addEventListener('viewbox-change', handleViewBoxChange as EventListener);
+    graphElement.addEventListener('theme-changed', handleThemeChanged as EventListener);
 
     graphContainerRef.current.appendChild(graphElement);
     graphElementRef.current = graphElement;
@@ -482,13 +512,21 @@ const SpyTialGraph = (props: SpyTialGraphProps) => {
         graphElementRef.current.removeEventListener('layout-complete', handleLayoutComplete as EventListener);
         graphElementRef.current.removeEventListener('node-drag-end', handleNodeDragEnd as EventListener);
         graphElementRef.current.removeEventListener('viewbox-change', handleViewBoxChange as EventListener);
-        
-        if (graphElementRef.current.clear) {
-          graphElementRef.current.clear();
+        graphElementRef.current.removeEventListener('theme-changed', handleThemeChanged as EventListener);
+
+        // Detach the element ourselves (before React removes the container) and
+        // swallow any error: spytial-core's disconnectedCallback can throw an
+        // InvalidStateError (getPointAtLength on an empty edge path) during
+        // dispose, and that must not be allowed to break React's unmount.
+        try {
+          graphElementRef.current.clear?.();
+        } catch {
+          /* ignore */
         }
-        // Remove the element we added
-        if (graphContainerRef.current && graphElementRef.current.parentNode === graphContainerRef.current) {
-          graphContainerRef.current.removeChild(graphElementRef.current);
+        try {
+          graphElementRef.current.remove();
+        } catch {
+          /* ignore spytial-core dispose throw */
         }
       }
       graphElementRef.current = null;
@@ -503,11 +541,17 @@ const SpyTialGraph = (props: SpyTialGraphProps) => {
     }
   }, [datum.data, cndSpec, timeIndex, loadGraph, isCndCoreReady]);
 
+  // App -> graph sync: re-tint the live graph whenever the app color mode
+  // changes (setTheme re-tints in place, no re-render needed).
+  useEffect(() => {
+    graphElementRef.current?.setTheme?.(colorMode);
+  }, [colorMode]);
+
   return (
-    <div 
+    <div
       className="absolute inset-0 flex flex-col"
-      style={{ 
-        background: 'white',
+      style={{
+        background: 'var(--ccd-surface)',
         overflow: 'hidden'
       }}
     >
@@ -523,11 +567,11 @@ const SpyTialGraph = (props: SpyTialGraphProps) => {
       />
       {/* React-managed overlay elements */}
       {isLoading && (
-        <div 
-          className="absolute inset-0 flex items-center justify-center bg-white bg-opacity-75"
-          style={{ zIndex: 10, pointerEvents: 'none' }}
+        <div
+          className="absolute inset-0 flex items-center justify-center"
+          style={{ zIndex: 10, pointerEvents: 'none', background: 'var(--ccd-surface)', opacity: 0.75 }}
         >
-          <div className="text-gray-600">Loading graph...</div>
+          <div style={{ color: 'var(--ccd-ink-muted)' }}>Loading graph...</div>
         </div>
       )}
       {error && (

--- a/packages/sterling/src/components/Minimap/graph.ts
+++ b/packages/sterling/src/components/Minimap/graph.ts
@@ -76,7 +76,7 @@ function edgeStyles(graph: Graph): Record<string, CSSProperties> {
   const edgeStyles: Record<string, CSSProperties> = {};
   getEdges(graph).forEach((edge) => {
     edgeStyles[`${edge.id}`] = {
-      stroke: '#4A5568',
+      stroke: 'var(--ccd-minimap-edge)',
       strokeWidth: 1,
       fill: 'none'
     };
@@ -92,7 +92,7 @@ function nodeLabels(graph: Graph, current: number): Record<string, LabelDef[]> {
       {
         text: node.id,
         style: {
-          fill: active ? 'white' : '#4A5568',
+          fill: active ? '#ffffff' : 'var(--ccd-minimap-node-stroke)',
           fontFamily: 'monospace',
           fontSize: '10px',
           fontWeight: active ? 'bold' : 'normal',
@@ -128,9 +128,9 @@ function nodeStyles(
   getNodes(graph).forEach((node) => {
     const active = node.id === `${current}`;
     nodeStyles[node.id] = {
-      stroke: active ? '#3B82F6' : '#4A5568',
+      stroke: active ? 'var(--ccd-minimap-node-active)' : 'var(--ccd-minimap-node-stroke)',
       strokeWidth: 1,
-      fill: active ? '#3B82F6' : 'white',
+      fill: active ? 'var(--ccd-minimap-node-active)' : 'var(--ccd-minimap-node-fill)',
       cursor: 'pointer'
     };
   });

--- a/packages/sterling/src/components/ScriptView/ScriptEditor.tsx
+++ b/packages/sterling/src/components/ScriptView/ScriptEditor.tsx
@@ -4,6 +4,8 @@ import { useCallback, useEffect, useState } from 'react';
 import { default as MonacoEditor, monaco } from 'react-monaco-editor';
 import { ScriptVariable } from '../../state/script/script';
 import { alloyDefs, generateAlloyVariablesModel } from './alloyModel';
+import { useSterlingSelector } from '../../state/hooks';
+import { selectColorMode } from '../../state/selectors';
 import IStandaloneCodeEditor = editor.IStandaloneCodeEditor;
 
 interface ScriptEditorProps {
@@ -26,6 +28,7 @@ const ScriptEditor = (props: ScriptEditorProps) => {
   } = props;
 
   const [editor, setEditor] = useState<IStandaloneCodeEditor>();
+  const colorMode = useSterlingSelector(selectColorMode);
 
   const editorDidMount = useCallback((editor: IStandaloneCodeEditor) => {
     editorRef(editor);
@@ -72,9 +75,10 @@ const ScriptEditor = (props: ScriptEditorProps) => {
   }, [editor, variables]);
 
   return (    
-    <MonacoEditor      
+    <MonacoEditor
       data-testid='script-view-monaco-editor'
       language='javascript'
+      theme={colorMode === 'dark' ? 'vs-dark' : 'vs'}
       options={{
         automaticLayout: true,
         scrollBeyondLastLine: false,

--- a/packages/sterling/src/components/ScriptView/ScriptViewDatum.tsx
+++ b/packages/sterling/src/components/ScriptView/ScriptViewDatum.tsx
@@ -143,7 +143,7 @@ const ScriptViewDatum = (props: ScriptViewDatumProps) => {
                 The slightly off-white background color shows the actual full SVG area.*/}
             {stage === 'svg' && 
               <div aria-label='SVG Visualization' id='svg-container' style={{height: '100%', width: '100%', overflow: 'scroll'}}>
-                <svg ref={svgRef} style={{width:'100%', height:'100%', backgroundColor: 'snow'}}/>
+                <svg ref={svgRef} style={{width:'100%', height:'100%', backgroundColor: 'var(--ccd-surface-muted)'}}/>
               </div>}
           </Pane>
           <Pane className='relative' aria-label='Visualization Script' data-testid='script-editor-pane'>

--- a/packages/sterling/src/components/ScriptView/ScriptViewHeader.tsx
+++ b/packages/sterling/src/components/ScriptView/ScriptViewHeader.tsx
@@ -14,7 +14,7 @@ const ScriptViewHeader = (props: ScriptViewHeaderProps) => {
   const command = parsed.command;
   return (
     <div className='w-full flex items-center space-x-2 px-2'>
-      <PaneTitle className='text-gray-400'>ID: {id}</PaneTitle>
+      <PaneTitle className='text-ink-faint'>ID: {id}</PaneTitle>
       <PaneTitle>{command}</PaneTitle>
       <div className='grow' />
       <ScriptViewHeaderButtons onExecute={onExecute} />

--- a/packages/sterling/src/components/TableView/Table.tsx
+++ b/packages/sterling/src/components/TableView/Table.tsx
@@ -19,7 +19,7 @@ const Table = (props: TableProps) => {
   return (
     <table className='prose shadow m-2 boarder prose text-xs font-mono' summary={data.title} role="table" style={style}>
     <caption className='prose prose-sm font-semibold px-2 py-1 border shadow' style={{ textAlign: 'left'}}>{data.title}</caption>
-    <thead className='bg-slate-100'>
+    <thead className='bg-surface-sunken'>
       <tr>
         {data.headers && data.headers.map((header, index) => {
           return (
@@ -42,7 +42,7 @@ const Table = (props: TableProps) => {
             {row.map((val, colIndex) => {
               return (
                 <td
-                  className='px-2 py-0.5 bg-white boarder'
+                  className='px-2 py-0.5 bg-surface boarder'
                   key={`${rowIndex}${colIndex}`}
                   headers={`header-${colIndex}`}
                 >

--- a/packages/sterling/src/components/TableView/TableViewHeader.tsx
+++ b/packages/sterling/src/components/TableView/TableViewHeader.tsx
@@ -12,7 +12,7 @@ const TableViewHeader = (props: TableViewHeaderProps) => {
   const command = parsed.command;
   return (
     <div className='w-full flex items-center space-x-2 px-2'>
-      <PaneTitle className='text-gray-400'>ID: {id}</PaneTitle>
+      <PaneTitle className='text-ink-faint'>ID: {id}</PaneTitle>
       <PaneTitle>{command}</PaneTitle>
       <div className='grow' />
       {buttons &&

--- a/packages/sterling/src/index.tsx
+++ b/packages/sterling/src/index.tsx
@@ -11,7 +11,13 @@ import { ChakraProvider } from '@chakra-ui/react';
 import { sterlingTheme } from '@/sterling-ui';
 import { Sterling } from './components/Sterling';
 import store from './state/store';
+import { wireColorMode } from './theme/wireColorMode';
+import '../../sterling-ui/src/themeVars.css';
 import './index.css';
+
+// Reflect the color mode onto <html> before first paint so the app renders in
+// the right theme, and keep it in sync thereafter.
+wireColorMode(store);
 
 ReactDOM.render(
   <React.StrictMode>

--- a/packages/sterling/src/state/selectors.ts
+++ b/packages/sterling/src/state/selectors.ts
@@ -38,6 +38,7 @@ import { ScriptStageType, ScriptVariable } from './script/script';
 import scriptSelectors from './script/scriptSelectors';
 import { SterlingState } from './store';
 import { TableData } from './table/table';
+import { ColorMode } from '../theme/colorMode';
 import {
   GraphDrawerView,
   MainView,
@@ -62,6 +63,13 @@ export function selectSelectedGenerator(
   state: SterlingState
 ): string | undefined {
   return uiSelectors.selectSelectedGenerator(state.ui);
+}
+
+/**
+ * Select the active app color mode (light/dark).
+ */
+export function selectColorMode(state: SterlingState): ColorMode {
+  return uiSelectors.selectColorMode(state.ui);
 }
 
 

--- a/packages/sterling/src/state/ui/ui.ts
+++ b/packages/sterling/src/state/ui/ui.ts
@@ -1,3 +1,5 @@
+import { ColorMode, resolveInitialColorMode } from '../../theme/colorMode';
+
 export type GraphView = 'GraphView';
 export type TableView = 'TableView';
 export type ScriptView = 'ScriptView';
@@ -29,6 +31,10 @@ export interface UiState {
   // the graph view drawer states
   // The generator name selected in the explorer dropdown
   selectedGenerator: string | undefined;
+
+  // active app color mode (light/dark); reflected onto <html> data-theme and
+  // synced to the graph's theme
+  colorMode: ColorMode;
 }
 
 /**
@@ -45,7 +51,8 @@ export const newUiState = (initialView?: MainView): UiState => {
     tableViewDrawer: null,
     scriptViewDrawer: 'variables',
     editViewDrawer: null,
-    selectedGenerator: undefined
+    selectedGenerator: undefined,
+    colorMode: resolveInitialColorMode()
   };
 };
 

--- a/packages/sterling/src/state/ui/uiReducers.ts
+++ b/packages/sterling/src/state/ui/uiReducers.ts
@@ -1,4 +1,5 @@
 import { PayloadAction } from '@reduxjs/toolkit';
+import { ColorMode } from '../../theme/colorMode';
 import {
   CommonDrawerView,
   GraphDrawerView,
@@ -95,6 +96,16 @@ function selectedGeneratorChanged(
   state.selectedGenerator = view.generatorName
 }
 
+/** Set the active color mode (e.g. when synced from the graph's theme). */
+function colorModeSet(state: UiState, action: PayloadAction<ColorMode>) {
+  state.colorMode = action.payload;
+}
+
+/** Toggle the active color mode (the in-app light/dark switch). */
+function colorModeToggled(state: UiState) {
+  state.colorMode = state.colorMode === 'dark' ? 'light' : 'dark';
+}
+
 
 
 export default {
@@ -104,5 +115,7 @@ export default {
   tableDrawerViewChanged,
   scriptDrawerViewChanged,
   editDrawerViewChanged,
-  selectedGeneratorChanged
+  selectedGeneratorChanged,
+  colorModeSet,
+  colorModeToggled
 };

--- a/packages/sterling/src/state/ui/uiSelectors.ts
+++ b/packages/sterling/src/state/ui/uiSelectors.ts
@@ -1,4 +1,5 @@
 import { createSelector } from '@reduxjs/toolkit';
+import { ColorMode } from '../../theme/colorMode';
 import {
   GraphDrawerView,
   MainView,
@@ -98,6 +99,11 @@ function selectSelectedGenerator(state: UiState): string | undefined {
   return state.selectedGenerator;
 }
 
+/** Select the active color mode. */
+function selectColorMode(state: UiState): ColorMode {
+  return state.colorMode;
+}
+
 
 export default {
   selectAvailableViews,
@@ -108,5 +114,6 @@ export default {
   selectEditDrawer,
   selectDrawerIsCollapsed,
   selectDrawerView,
-  selectSelectedGenerator
+  selectSelectedGenerator,
+  selectColorMode
 };

--- a/packages/sterling/src/state/ui/uiSlice.ts
+++ b/packages/sterling/src/state/ui/uiSlice.ts
@@ -22,6 +22,8 @@ export const {
   tableDrawerViewChanged,
   scriptDrawerViewChanged,
   editDrawerViewChanged,
-  selectedGeneratorChanged
+  selectedGeneratorChanged,
+  colorModeSet,
+  colorModeToggled
 } = uiSlice.actions;
 export default uiSlice.reducer;

--- a/packages/sterling/src/theme/colorMode.ts
+++ b/packages/sterling/src/theme/colorMode.ts
@@ -1,0 +1,48 @@
+/**
+ * App color mode: a light/dark switch for the Cope-and-Drag chrome.
+ *
+ * The active mode is reflected onto <html> as `data-theme`, which drives the
+ * CSS-variable layer in `sterling-ui/src/themeVars.css`. The graph component
+ * keeps its own theme; the two are synced (app is the source of truth) — see
+ * GraphView/SpyTialGraph. Maps directly to the graph's `light`/`dark` theme
+ * names, so `setTheme(colorMode)` just works.
+ */
+
+export type ColorMode = 'light' | 'dark';
+
+const STORAGE_KEY = 'ccd-color-mode';
+
+export function isColorMode(value: unknown): value is ColorMode {
+  return value === 'light' || value === 'dark';
+}
+
+/** Resolve the initial mode: a persisted manual choice, else light. */
+export function resolveInitialColorMode(): ColorMode {
+  try {
+    const stored = window.localStorage.getItem(STORAGE_KEY);
+    if (isColorMode(stored)) return stored;
+  } catch {
+    /* no storage (private mode / non-DOM env) */
+  }
+  return 'light';
+}
+
+/** Reflect the mode onto <html> so the CSS-variable layer follows. */
+export function applyColorModeToDom(mode: ColorMode): void {
+  try {
+    const el = document.documentElement;
+    el.setAttribute('data-theme', mode);
+    el.style.colorScheme = mode; // native form controls / scrollbars
+  } catch {
+    /* non-DOM environment (tests) */
+  }
+}
+
+/** Persist a manual choice so it is remembered next load. */
+export function persistColorMode(mode: ColorMode): void {
+  try {
+    window.localStorage.setItem(STORAGE_KEY, mode);
+  } catch {
+    /* ignore */
+  }
+}

--- a/packages/sterling/src/theme/wireColorMode.ts
+++ b/packages/sterling/src/theme/wireColorMode.ts
@@ -1,0 +1,22 @@
+import type store from '../state/store';
+import { selectColorMode } from '../state/selectors';
+import { applyColorModeToDom, persistColorMode } from './colorMode';
+
+/**
+ * Keep <html> in sync with the store's color mode: apply the initial mode, then
+ * on every change reflect it to the DOM (driving the CSS-variable layer) and
+ * persist it. Returns the store unsubscribe function.
+ */
+export function wireColorMode(appStore: typeof store): () => void {
+  let prev = selectColorMode(appStore.getState());
+  applyColorModeToDom(prev);
+
+  return appStore.subscribe(() => {
+    const next = selectColorMode(appStore.getState());
+    if (next !== prev) {
+      prev = next;
+      applyColorModeToDom(next);
+      persistColorMode(next);
+    }
+  });
+}

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -1,10 +1,50 @@
+// Semantic colors resolve to the CSS-variable layer in
+// `packages/sterling-ui/src/themeVars.css`, so a single `data-theme` flip on
+// <html> re-themes every utility — no `dark:` variants needed. The default
+// Tailwind palette stays available alongside these.
 module.exports = {
   content: [
     './packages/sterling/**/*.{tsx,jsx}',
     './packages/sterling-ui/**/*.{tsx,jsx}'
   ],
+  darkMode: ['selector', '[data-theme="dark"]'],
   theme: {
-    extend: {}
+    extend: {
+      colors: {
+        // Surfaces
+        bg: 'var(--ccd-bg)',
+        surface: 'var(--ccd-surface)',
+        'surface-muted': 'var(--ccd-surface-muted)',
+        'surface-sunken': 'var(--ccd-surface-sunken)',
+        // Ink (text)
+        ink: 'var(--ccd-ink)',
+        'ink-muted': 'var(--ccd-ink-muted)',
+        'ink-faint': 'var(--ccd-ink-faint)',
+        'ink-decorative': 'var(--ccd-ink-decorative)',
+        // Rules
+        rule: 'var(--ccd-rule)',
+        'rule-strong': 'var(--ccd-rule-strong)',
+        // Accent
+        accent: 'var(--ccd-accent)',
+        'accent-bg': 'var(--ccd-accent-bg)',
+        'accent-border': 'var(--ccd-accent-border)',
+        'accent-ink': 'var(--ccd-accent-ink)',
+        'on-accent': 'var(--ccd-on-accent)',
+        // Status
+        success: 'var(--ccd-success)',
+        'success-bg': 'var(--ccd-success-bg)',
+        'success-border': 'var(--ccd-success-border)',
+        danger: 'var(--ccd-danger)',
+        'danger-bg': 'var(--ccd-danger-bg)',
+        'danger-border': 'var(--ccd-danger-border)',
+        warning: 'var(--ccd-warning)',
+        'warning-bg': 'var(--ccd-warning-bg)',
+        'warning-border': 'var(--ccd-warning-border)',
+        info: 'var(--ccd-info)',
+        'info-bg': 'var(--ccd-info-bg)',
+        'info-border': 'var(--ccd-info-border)'
+      }
+    }
   },
   plugins: [require('@tailwindcss/typography'), require('@tailwindcss/forms')],
   important: true

--- a/yarn.lock
+++ b/yarn.lock
@@ -9453,10 +9453,10 @@ sprintf-js@~1.0.2:
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
   integrity sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==
 
-spytial-core@2.7.1:
-  version "2.7.1"
-  resolved "https://registry.yarnpkg.com/spytial-core/-/spytial-core-2.7.1.tgz#8e85bca82468dd2304237b14ea780e8292fd67aa"
-  integrity sha512-yrCjlJum6joSK/J9L+1puZKknMFhkAq91nLup54rRwwlO2IJmRFbnzch0kUlA2CoGHe//K+hyToMcJ4aa2NraQ==
+spytial-core@2.8.0:
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/spytial-core/-/spytial-core-2.8.0.tgz#66e451b31f2ef1e0b7048a84f78eb0ed1549e0fc"
+  integrity sha512-2d7qQcGg458WY+6sivQOLpFm6eLEkuniTmGIME8x2CNgQfKvxq12Thgsy9pWLgHlwdjQpqnMdnBNfthcTUoz/g==
   dependencies:
     "@types/d3" "^4.13.12"
     "@types/graphlib-dot" "^0.6.4"


### PR DESCRIPTION
## Summary

Adds a light/dark mode that covers the entire app — shell, all drawers, Table, Script (Monaco), Edit, minimap — and keeps it in sync with the graph's own theme (spytial-core 2.8.0) in both directions.

### Theme system
- **CSS-variable token layer** (`packages/sterling-ui/src/themeVars.css`): full light/dark palettes (surfaces incl. sunken, ink scale, rules, accent + on-accent, status trios, overlay scrim, minimap). `tokens.ts` resolves every `tokens.color.*` to `var(--ccd-*)`, so the Chakra shell, all component themes, and inline token usages re-theme on a single `data-theme` flip on `<html>`. Light mode is pixel-identical to before.
- **Tailwind semantic colors** mapped to the same vars; hardcoded utilities (`bg-white`, `text-gray-*`, `border-slate-*`, …) swept across drawers, Table, Edit, headers, synthesis, evaluator, and the minimap — no `dark:` variants needed.
- **`colorMode` in the ui slice** + a NavBar sun/moon toggle (available on every view), persisted to localStorage.
- Dark-mode remaps for two third-party surfaces: Tailwind `prose` (Table text) and spytial-core's embedded CnD editor widget (Layout drawer).

### Graph integration (spytial-core 2.8.0 theme API)
- **Two-way sync**: the app toggle drives every graph via `setTheme()`, and the graph's built-in Mode dropdown drives the app chrome via its `theme-changed` event. No feedback loops (`setTheme()` doesn't re-fire the event).
- All four graph surfaces (main graph, both multi-pane views, the Edit view's `structured-input-graph`) start on the app's theme and **re-tint in place** on toggle — no re-layout, which also avoids racing WebCola ticks against cleared selections.
- Monaco follows the app theme (`vs` / `vs-dark`).

### Robustness
- Graph mount effects now use `useLayoutEffect` with a guarded synchronous detach, containing spytial-core's `disconnectedCallback` throw (`getPointAtLength` on an empty edge path) so switching views can never break React unmounts. (Root-cause fixes for the dispose throw and the `clear()` tick-handler leak belong in spytial-core.)

Bumps spytial-core to 2.8.0 (published theme API) and the package version to 4.0.8.

## Test plan
- `yarn test` — 16 suites / 74 tests pass
- Manual preview (mock provider): toggled light/dark from the NavBar and from the graph's Mode dropdown; verified both sync directions, persistence across reloads, and screenshots of Graph / Table / Script / Edit / drawers in both modes
- Stress: 4 theme toggles interleaved with Graph→Script→Edit→Table mounts/unmounts plus rapid triple-Run — no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)