### PR TITLE
Fix GoPrimitiveDot import removed from react-icons/go

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sterling-layout",
   "description": "Cope and Drag (CnD): a fork of the Sterling visualizer that encodes spatial layout.",
-  "version": "4.0.8",
+  "version": "4.0.9",
   "main": "index.js",
   "author": "Siddhartha Prasad",
   "license": "MIT",

--- a/packages/sterling/src/components/AppStatusBar/ConnectionDot.tsx
+++ b/packages/sterling/src/components/AppStatusBar/ConnectionDot.tsx
@@ -1,5 +1,5 @@
 import { Icon, IconProps } from '@chakra-ui/react';
-import { GoPrimitiveDot } from 'react-icons/go';
+import { GoDotFill } from 'react-icons/go';
 
 interface ConnectionDotProps {
   isConnected: boolean;
@@ -8,7 +8,7 @@ interface ConnectionDotProps {
 const ConnectionDot = (props: IconProps & ConnectionDotProps) => {
   const { isConnected, ...rest } = props;
   const color = isConnected ? 'green.500' : 'red.500';
-  return <Icon as={GoPrimitiveDot} color={color} {...rest} />;
+  return <Icon as={GoDotFill} color={color} {...rest} />;
 };
 
 export { ConnectionDot };


### PR DESCRIPTION
## Summary
`react-icons` renamed `GoPrimitiveDot` to `GoDotFill` in a newer version, producing a webpack build warning:

> export 'GoPrimitiveDot' (imported as 'GoPrimitiveDot') was not found in 'react-icons/go'

This updates the import and JSX usage in `ConnectionDot.tsx` to `GoDotFill`, and bumps the patch version to 4.0.9.

## Notes
The remaining `color-adjust` deprecation warning comes from a CSS dependency (autoprefixer) and is unrelated to app code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)