### PR TITLE
Update to spytial-core 2.9.0 with domain-aware spec editor

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "react-monaco-editor": "^0.47.0",
     "react-redux": "^7.2.6",
     "redux": "^4.1.2",
-    "spytial-core": "2.8.1",
+    "spytial-core": "2.9.0",
     "transformation-matrix": "^2.10.0",
     "ts-is-present": "^1.2.2",
     "uuid": "^9.0.0"

--- a/packages/sterling-ui/src/themeVars.css
+++ b/packages/sterling-ui/src/themeVars.css
@@ -85,16 +85,34 @@ html {
  * dark mode so table text stays legible.
  */
 /*
- * spytial-core's embedded CnD editor widget (Layout drawer: Code View /
- * Structured Builder) hardcodes a white form background; theme it in dark mode
- * via its stable class names. Light mode is untouched.
+ * spytial-core's embedded spec editor (Layout drawer) is themed entirely
+ * through its own --spytial-ed-* custom properties, which otherwise fall back
+ * to the editor's built-in light preset. Remap them onto our --ccd-* tokens so
+ * the editor tracks the app theme in both light and dark — flipping with
+ * data-theme like everything else, no `theme` prop and no React re-render.
+ * The editor renders its popups (autocomplete, add-menu) inside its own
+ * `.spytial-ed` root, so scoping the variables here reaches all of it.
+ * (spytial-core >= 2.9.0; replaces the old .cnd-layout-interface rule.)
  */
-[data-theme='dark'] .cnd-layout-interface textarea,
-[data-theme='dark'] .cnd-layout-interface .form-control,
-[data-theme='dark'] .code-view-textarea {
-  background-color: var(--ccd-surface-muted);
-  color: var(--ccd-ink);
-  border-color: var(--ccd-rule-strong);
+.spytial-ed {
+  --spytial-ed-surface: var(--ccd-surface);
+  --spytial-ed-surface-raised: var(--ccd-surface-muted);
+  --spytial-ed-border: var(--ccd-rule);
+  --spytial-ed-text: var(--ccd-ink);
+  --spytial-ed-text-muted: var(--ccd-ink-muted);
+  --spytial-ed-accent: var(--ccd-accent);
+  --spytial-ed-accent-text: var(--ccd-on-accent);
+  --spytial-ed-danger: var(--ccd-danger);
+  --spytial-ed-warning: var(--ccd-warning);
+  --spytial-ed-success: var(--ccd-success);
+
+  /* Selector / YAML syntax highlighting — themed hues that flip with the app. */
+  --spytial-ed-syn-keyword: var(--ccd-accent);
+  --spytial-ed-syn-type: var(--ccd-info);
+  --spytial-ed-syn-relation: var(--ccd-success);
+  --spytial-ed-syn-operator: var(--ccd-ink-muted);
+  --spytial-ed-syn-string: var(--ccd-warning);
+  --spytial-ed-syn-comment: var(--ccd-ink-faint);
 }
 
 [data-theme='dark'] .prose {

--- a/packages/sterling/src/components/AppDrawer/graph/theme/GraphLayoutDrawer.tsx
+++ b/packages/sterling/src/components/AppDrawer/graph/theme/GraphLayoutDrawer.tsx
@@ -141,6 +141,28 @@ const GraphLayoutDrawer = () => {
     ensureBootstrapLoaded();
   }, []);
 
+  // Push the active datum's data instance into SpyTial's shared instance state
+  // so the mounted spec editor (spytial-core >= 2.9.0's rebuilt structured
+  // builder) becomes domain-aware: relation/type dropdowns and selector
+  // autocomplete are derived from this instance. Mirrors the alloy-demo's
+  // `window.updateInstanceFromReact(alloyDataInstance)` call. Re-runs as the
+  // datum or time step changes so the editor's domain tracks what's displayed.
+  useEffect(() => {
+    const xml = datum?.data;
+    if (!xml) return;
+    const core = getSpytialCore();
+    if (!core?.AlloyInstance?.parseAlloyXML || !core.AlloyDataInstance) return;
+    try {
+      const alloyDatum = core.AlloyInstance.parseAlloyXML(xml);
+      if (!alloyDatum.instances || alloyDatum.instances.length === 0) return;
+      const instanceIndex = Math.min(timeIndex, alloyDatum.instances.length - 1);
+      const alloyDataInstance = new core.AlloyDataInstance(alloyDatum.instances[instanceIndex]);
+      window.updateInstanceFromReact?.(alloyDataInstance);
+    } catch (err) {
+      console.error('Failed to push data instance to spec editor:', err);
+    }
+  }, [datum?.data, timeIndex]);
+
   // Mount the CnD Layout Interface from SpyTial
   useEffect(() => {
     if (cndEditorRef.current && !isEditorMounted && datum) {

--- a/packages/sterling/src/utils/spytialCore.ts
+++ b/packages/sterling/src/utils/spytialCore.ts
@@ -84,6 +84,12 @@ declare global {
     CnDCore?: SpytialCoreApi;
     mountCndLayoutInterface?: (elementId?: string, options?: any) => void;
     mountErrorMessageModal?: (elementId?: string) => void;
+    /**
+     * Push a data instance into SpyTial's shared instance state so the mounted
+     * spec editor (spytial-core >= 2.9.0) becomes domain-aware: type/relation
+     * dropdowns and selector autocomplete are derived from this instance.
+     */
+    updateInstanceFromReact?: (instance: any) => void;
     showParseError?: (message: string, context: string) => void;
     showGeneralError?: (message: string) => void;
     showPositionalError?: (errorMessages: any) => void;

--- a/yarn.lock
+++ b/yarn.lock
@@ -9453,10 +9453,10 @@ sprintf-js@~1.0.2:
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
   integrity sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==
 
-spytial-core@2.8.1:
-  version "2.8.1"
-  resolved "https://registry.yarnpkg.com/spytial-core/-/spytial-core-2.8.1.tgz#83eaeaac27d7c7e72fa2ee21edac763a18cdb50d"
-  integrity sha512-XAxsI4V2XaxggPXqRszpEQn/lOvDpj9fK6vxgSMw1Y3OAuyJcoOvYXiqkIo/EIWgPyREyQFeeFrBEFLK7S/YvA==
+spytial-core@2.9.0:
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/spytial-core/-/spytial-core-2.9.0.tgz#2d9fa3623d9ab0213ff661028e9720a868c66f10"
+  integrity sha512-oj2gonnTyapA/oaJU1gvOBBSbqJDf1nIhRqOxMoIsG6t/9GMHvJfJytK0CyE7BS9nZ28lFUrTewVEESVGCa5Pw==
   dependencies:
     "@types/d3" "^4.13.12"
     "@types/graphlib-dot" "^0.6.4"


### PR DESCRIPTION
## Summary

Updates copeanddrag to **spytial-core 2.9.0** and adopts the new mounting style for the rebuilt structured spec editor (the new `SpecEditor` behind the `CndLayoutInterface` back-compat wrapper, sidprasad/spytial-core#478).

## Changes

- **Bump** `spytial-core` 2.8.1 → 2.9.0 (`package.json` + `yarn.lock`). Webpack's `CopyWebpackPlugin` auto-vendors the new bundles, so `index.html` is unchanged, and the existing `mountCndLayoutInterface('cnd-editor-mount', …)` call keeps working against the back-compat wrapper.
- **Domain awareness** — push the active datum's `AlloyDataInstance` into SpyTial's shared instance state via `window.updateInstanceFromReact(...)` on `[datum.data, timeIndex]`, so the editor's selector fields get relation/type dropdowns and autocomplete derived from the displayed model. (`GraphLayoutDrawer.tsx`, `spytialCore.ts`)
- **Theming** — map the editor's `--spytial-ed-*` tokens onto our `--ccd-*` design tokens in `themeVars.css`, so the editor tracks light/dark via `data-theme` like the rest of the app (no `theme` prop, no React re-render). Replaces the now-dead `.cnd-layout-interface` dark rule that targeted the old editor.

## Verification

Verified end-to-end on the `cnd-mock` dev server (river-crossing model):

- ✅ App builds & runs clean; graph renders (9 nodes); 2.9.0's taut-routing default active; no new console errors.
- ✅ New `SpecEditor` mounts via the existing mount call (Builder/Code tabs, undo/redo, initial `hideDisconnectedBuiltIns` directive loaded).
- ✅ Domain-aware autocomplete lists the model's relations (`animals`, `location`), types (`Goat`, `Wolf`, …), and atoms.
- ✅ Editor follows light/dark: surface `#ffffff` ↔ `#1e2127`, accent `#5a3d8a` ↔ `#b9a3e3` — including the in-editor autocomplete popup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
