### PR TITLE
Auto-refit the graph viewport after each render

### DIFF
--- a/packages/sterling/src/components/GraphView/MultiProjectionGraph.tsx
+++ b/packages/sterling/src/components/GraphView/MultiProjectionGraph.tsx
@@ -188,6 +188,10 @@ const SingleProjectionPane = (props: SingleProjectionPaneProps) => {
         }
         graphElementRef.current.setTheme?.(colorModeRef.current);
         await graphElementRef.current.renderLayout(layoutResult.layout);
+        // Re-fit the viewport to this projection's content. The graph otherwise
+        // keeps the prior viewport once the user has zoomed/panned, leaving the
+        // projection framed by a stale view. (See SpyTialGraph for the rationale.)
+        graphElementRef.current.resetViewToFitContent?.();
       }
 
       setIsLoading(false);

--- a/packages/sterling/src/components/GraphView/MultiTemporalGraph.tsx
+++ b/packages/sterling/src/components/GraphView/MultiTemporalGraph.tsx
@@ -146,6 +146,10 @@ const SingleTemporalPane = (props: SingleTemporalPaneProps) => {
         }
         graphElementRef.current.setTheme?.(colorModeRef.current);
         await graphElementRef.current.renderLayout(layoutResult.layout);
+        // Re-fit the viewport to this time step's content. The graph otherwise
+        // keeps the prior viewport once the user has zoomed/panned, leaving the
+        // step framed by a stale view. (See SpyTialGraph for the full rationale.)
+        graphElementRef.current.resetViewToFitContent?.();
       }
 
       setIsLoading(false);

--- a/packages/sterling/src/components/GraphView/SpyTialGraph.tsx
+++ b/packages/sterling/src/components/GraphView/SpyTialGraph.tsx
@@ -62,6 +62,9 @@ declare global {
       getLayoutState?: () => LayoutState;
       addToolbarControl?: (element: HTMLElement) => void;
       clear?: () => void;
+      // Clears the manual-zoom flag and fits/centers content to the viewport
+      // (same as the built-in recenter button). spytial-core >= 2.8.0.
+      resetViewToFitContent?: () => void;
       // Theme API (spytial-core >= 2.8.0). setTheme re-tints a live graph with
       // no re-render; the element also fires a 'theme-changed' event when the
       // user picks a theme in its built-in Mode dropdown.
@@ -415,6 +418,15 @@ const SpyTialGraph = (props: SpyTialGraphProps) => {
           layoutResult.layout,
           Object.keys(renderOptions).length > 0 ? renderOptions : undefined
         );
+
+        // Re-fit the viewport to the freshly rendered content. With morph
+        // transitions the graph restores the prior viewport and suppresses its
+        // own auto-fit once the user has zoomed/panned, which leaves a new
+        // instance / layout / time step framed by the stale viewport (users
+        // then had to click recenter). Every loadGraph() here is a content
+        // change — zoom/pan/drag are internal and never re-render — so fitting
+        // unconditionally is correct; in-instance manual zoom is untouched.
+        graphElementRef.current.resetViewToFitContent?.();
 
         // Track the current instance for next step's sequence policy
         prevInstanceRef.current = alloyDataInstance;


### PR DESCRIPTION
## Problem

The graph doesn't reliably re-center/fit when content changes — next instance, temporal trace step, or a newly applied layout — so users have to click the recenter button manually.

## Root cause

The `webcola-cnd-graph` element preserves the prior viewport and suppresses its own auto-fit once the user has zoomed/panned (`userHasManuallyZoomed`), to keep viewport continuity during morph transitions. That flag persists on the element, so after a single zoom/pan every subsequent `renderLayout()` keeps the stale viewport.

## Fix

Call the element's public `resetViewToFitContent()` after each `renderLayout()` in all three graph components (`SpyTialGraph`, `MultiTemporalGraph`, `MultiProjectionGraph`). It's the exact method the recenter button uses (clears the flag + fits with a smooth transition). Every `renderLayout` in these components is a content change — zoom/pan/drag are internal and never re-render — so fitting unconditionally is correct, and a user's in-instance zoom is left untouched.

Independent of #126: `resetViewToFitContent()` has existed since spytial-core 2.8.1, so this works on `main` as-is.

## Verification

- ✅ A spy confirmed `resetViewToFitContent` is called after each render.
- ✅ Initial fit adapts to container size on a real render; no regression, no new console errors.
- ✅ Same method the working recenter button calls.
- ⚠️ The exact *zoom-then-navigate* cycle couldn't be driven inside the headless preview (a synthetic `WheelEvent` corrupts d3-zoom's state and toolbar `.click()`s don't register the gesture). A 10-second manual check — zoom in → Next/Apply → confirm it auto-recenters — is recommended.

## Trade-off

A user's manual zoom/pan no longer persists *across* instance/layout/time changes — which is the behavior the feedback requested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
