### PR TITLE
Time panel: Single / Sliding Window / Compare presentation modes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sterling-layout",
   "description": "Cope and Drag (CnD): a fork of the Sterling visualizer that encodes spatial layout.",
-  "version": "4.0.12",
+  "version": "4.0.13",
   "main": "index.js",
   "author": "Siddhartha Prasad",
   "license": "MIT",

--- a/packages/sterling-ui/src/themeVars.css
+++ b/packages/sterling-ui/src/themeVars.css
@@ -64,6 +64,7 @@
   --ccd-minimap-node-fill: #ffffff;
   --ccd-minimap-node-stroke: #4a5568;
   --ccd-minimap-node-active: #3b82f6;
+  --ccd-minimap-node-active-label: #ffffff;
   --ccd-minimap-edge: #4a5568;
   --ccd-minimap-selected-stroke: #333333;
 }
@@ -183,6 +184,7 @@ html body {
   --ccd-minimap-node-fill: #2b2f37;
   --ccd-minimap-node-stroke: #8b919b;
   --ccd-minimap-node-active: #5dade2;
+  --ccd-minimap-node-active-label: #11161d;
   --ccd-minimap-edge: #6b7280;
   --ccd-minimap-selected-stroke: #e6e7ea;
 }

--- a/packages/sterling/src/components/AppDrawer/graph/state/GraphStateDrawer.tsx
+++ b/packages/sterling/src/components/AppDrawer/graph/state/GraphStateDrawer.tsx
@@ -1,21 +1,38 @@
 import { PaneTitle } from '@/sterling-ui';
 import { useSterlingSelector } from '../../../../state/hooks';
-import { selectActiveDatum, selectDatumIsTrace } from '../../../../state/selectors';
+import {
+  selectActiveDatum,
+  selectDatumIsTrace,
+  selectPresentationMode
+} from '../../../../state/selectors';
 import { TimeSection } from './time/TimeSection';
 import { TemporalPolicySection } from './temporal/TemporalPolicySection';
+import { PresentationModeSelect } from './time/PresentationModeSelect';
+import { ComparisonLayoutToggle } from './time/ComparisonLayoutToggle';
 
 const GraphStateDrawer = () => {
   const activeDatum = useSterlingSelector(selectActiveDatum);
   const isTrace = useSterlingSelector((state) =>
     activeDatum ? selectDatumIsTrace(state, activeDatum) : false
   );
+  const mode = useSterlingSelector((state) =>
+    activeDatum ? selectPresentationMode(state, activeDatum) : 'single'
+  );
 
   if (!activeDatum) return null;
-  
+
+  // The pane-flow toggle only matters when multiple states are shown.
+  const showLayoutToggle = isTrace && (mode === 'window' || mode === 'compare');
+
   return (
     <div className='absolute inset-0 flex flex-col overflow-y-auto'>
-      {/* Temporal policy selector — always visible */}
-      <TemporalPolicySection datum={activeDatum} />
+      {/* Compact controls row: policy + presentation mode (+ pane flow when
+          multiple states are shown), all on one line to save vertical space. */}
+      <div className='flex flex-wrap items-center gap-x-4 gap-y-2 border-b border-rule px-3 py-2'>
+        <TemporalPolicySection datum={activeDatum} />
+        {isTrace && <PresentationModeSelect datum={activeDatum} />}
+        {showLayoutToggle && <ComparisonLayoutToggle datum={activeDatum} />}
+      </div>
 
       {isTrace ? (
         <TimeSection datum={activeDatum} />

--- a/packages/sterling/src/components/AppDrawer/graph/state/temporal/TemporalPolicySection.tsx
+++ b/packages/sterling/src/components/AppDrawer/graph/state/temporal/TemporalPolicySection.tsx
@@ -80,18 +80,19 @@ const TemporalPolicySection = ({ datum }: { datum: DatumParsed<any> }) => {
   };
 
   return (
-    <div className='px-4 py-3'>
-      <label
-        htmlFor='temporal-policy-select'
-        className='block text-xs font-semibold uppercase tracking-wide text-ink-muted mb-1'
-      >
-        Temporal Policy
-      </label>
+    <label
+      htmlFor='temporal-policy-select'
+      className='flex min-w-0 flex-1 items-center gap-2'
+      title={POLICY_OPTIONS.find((o) => o.value === currentPolicy)?.description}
+    >
+      <span className='whitespace-nowrap text-xs font-semibold uppercase tracking-wide text-ink-muted'>
+        Policy
+      </span>
       <select
         id='temporal-policy-select'
         value={currentPolicy}
         onChange={handleChange}
-        className='w-full rounded border border-rule-strong bg-surface px-3 py-2 text-sm shadow-sm focus:border-accent-border focus:outline-none focus:ring-1 focus:ring-accent'
+        className='min-w-0 flex-1 rounded border border-rule-strong bg-surface px-2 py-1 text-sm shadow-sm focus:border-accent-border focus:outline-none focus:ring-1 focus:ring-accent'
       >
         {POLICY_OPTIONS.map((opt) => (
           <option key={opt.value} value={opt.value}>
@@ -99,10 +100,7 @@ const TemporalPolicySection = ({ datum }: { datum: DatumParsed<any> }) => {
           </option>
         ))}
       </select>
-      <p className='mt-1 text-xs text-ink-faint'>
-        {POLICY_OPTIONS.find((o) => o.value === currentPolicy)?.description}
-      </p>
-    </div>
+    </label>
   );
 };
 

--- a/packages/sterling/src/components/AppDrawer/graph/state/time/ComparisonLayoutToggle.tsx
+++ b/packages/sterling/src/components/AppDrawer/graph/state/time/ComparisonLayoutToggle.tsx
@@ -1,0 +1,58 @@
+import { DatumParsed } from '@/sterling-connection';
+import { ReactElement } from 'react';
+import { MdViewColumn, MdViewStream } from 'react-icons/md';
+import type { ComparisonLayout } from '../../../../../state/graphs/graphs';
+import { comparisonLayoutSet } from '../../../../../state/graphs/graphsSlice';
+import {
+  useSterlingDispatch,
+  useSterlingSelector
+} from '../../../../../state/hooks';
+import { selectComparisonLayout } from '../../../../../state/selectors';
+
+const OPTIONS: { value: ComparisonLayout; label: string; icon: ReactElement }[] =
+  [
+    { value: 'horizontal', label: 'Side by side', icon: <MdViewColumn /> },
+    { value: 'vertical', label: 'Stacked', icon: <MdViewStream /> }
+  ];
+
+/** Compact two-button toggle for the flow of side-by-side state panes. */
+const ComparisonLayoutToggle = ({ datum }: { datum: DatumParsed<any> }) => {
+  const dispatch = useSterlingDispatch();
+  const layout = useSterlingSelector((state) =>
+    selectComparisonLayout(state, datum)
+  );
+
+  return (
+    <div
+      className='flex items-center gap-1'
+      role='group'
+      aria-label='Pane layout'
+    >
+      {OPTIONS.map((opt) => {
+        const active = opt.value === layout;
+        return (
+          <button
+            key={opt.value}
+            type='button'
+            title={opt.label}
+            aria-label={opt.label}
+            aria-pressed={active}
+            onClick={() =>
+              dispatch(comparisonLayoutSet({ datum, layout: opt.value }))
+            }
+            className={[
+              'rounded-md border p-1.5 text-base transition-colors',
+              active
+                ? 'border-accent-border bg-accent-bg text-accent-ink'
+                : 'border-rule text-ink-muted hover:bg-surface-sunken hover:text-ink'
+            ].join(' ')}
+          >
+            {opt.icon}
+          </button>
+        );
+      })}
+    </div>
+  );
+};
+
+export { ComparisonLayoutToggle };

--- a/packages/sterling/src/components/AppDrawer/graph/state/time/PresentationModeSelect.tsx
+++ b/packages/sterling/src/components/AppDrawer/graph/state/time/PresentationModeSelect.tsx
@@ -1,0 +1,97 @@
+import { DatumParsed } from '@/sterling-connection';
+import { useCallback } from 'react';
+import type { PresentationMode } from '../../../../../state/graphs/graphs';
+import {
+  presentationModeSet,
+  selectedTimeIndicesSet
+} from '../../../../../state/graphs/graphsSlice';
+import {
+  useSterlingDispatch,
+  useSterlingSelector
+} from '../../../../../state/hooks';
+import {
+  selectPresentationMode,
+  selectSelectedTimeIndices,
+  selectTimeIndex
+} from '../../../../../state/selectors';
+
+const MODE_OPTIONS: {
+  value: PresentationMode;
+  label: string;
+  description: string;
+}[] = [
+  {
+    value: 'single',
+    label: 'Single State',
+    description:
+      'Show one state at a time; scrub the timeline to move through the trace.'
+  },
+  {
+    value: 'window',
+    label: 'Sliding Window',
+    description:
+      'Show the state before, the current state, and the state after — side by side.'
+  },
+  {
+    value: 'compare',
+    label: 'Compare States',
+    description:
+      'Click states on the timeline to show any set of them side by side.'
+  }
+];
+
+/** Compact dropdown that picks how trace states are presented. */
+const PresentationModeSelect = ({ datum }: { datum: DatumParsed<any> }) => {
+  const dispatch = useSterlingDispatch();
+  const mode = useSterlingSelector((state) =>
+    selectPresentationMode(state, datum)
+  );
+  const compareSet = useSterlingSelector((state) =>
+    selectSelectedTimeIndices(state, datum)
+  );
+  const timeIndex = useSterlingSelector((state) =>
+    selectTimeIndex(state, datum)
+  );
+
+  const changeMode = useCallback(
+    (next: PresentationMode) => {
+      if (next === mode) return;
+      // Entering compare with no prior selection: seed it with the current
+      // state so there's something on screen. A previous compare selection is
+      // preserved (we only seed when empty).
+      if (next === 'compare' && compareSet.length === 0) {
+        dispatch(
+          selectedTimeIndicesSet({ datum, selectedIndices: [timeIndex] })
+        );
+      }
+      dispatch(presentationModeSet({ datum, mode: next }));
+    },
+    [mode, compareSet.length, dispatch, datum, timeIndex]
+  );
+
+  return (
+    <label
+      htmlFor='presentation-mode-select'
+      className='flex min-w-0 flex-1 items-center gap-2'
+      title={MODE_OPTIONS.find((o) => o.value === mode)?.description}
+    >
+      <span className='whitespace-nowrap text-xs font-semibold uppercase tracking-wide text-ink-muted'>
+        Show
+      </span>
+      <select
+        id='presentation-mode-select'
+        value={mode}
+        onChange={(e) => changeMode(e.target.value as PresentationMode)}
+        className='min-w-0 flex-1 rounded border border-rule-strong bg-surface px-2 py-1 text-sm shadow-sm focus:border-accent-border focus:outline-none focus:ring-1 focus:ring-accent'
+      >
+        {MODE_OPTIONS.map((opt) => (
+          <option key={opt.value} value={opt.value}>
+            {opt.label}
+          </option>
+        ))}
+      </select>
+    </label>
+  );
+};
+
+export { PresentationModeSelect };

--- a/packages/sterling/src/components/AppDrawer/graph/state/time/TimePicker.tsx
+++ b/packages/sterling/src/components/AppDrawer/graph/state/time/TimePicker.tsx
@@ -1,23 +1,63 @@
 import { DatumParsed } from '@/sterling-connection';
 import { useCallback, useState } from 'react';
-import { timeIndexSet, timeIndexToggled, selectedTimeIndicesSet } from '../../../../../state/graphs/graphsSlice';
+import type { PresentationMode } from '../../../../../state/graphs/graphs';
+import {
+  presentationModeSet,
+  selectedTimeIndicesSet,
+  timeIndexSet,
+  timeIndexToggled
+} from '../../../../../state/graphs/graphsSlice';
 import {
   useSterlingDispatch,
   useSterlingSelector
 } from '../../../../../state/hooks';
 import {
+  selectEffectiveTimeIndices,
   selectLoopbackIndex,
+  selectPresentationMode,
+  selectSelectedTimeIndices,
   selectTimeIndex,
-  selectTraceLength,
-  selectSelectedTimeIndices
+  selectTraceLength
 } from '../../../../../state/selectors';
 import { Minimap } from '../../../../Minimap/Minimap';
+
+const MODE_OPTIONS: {
+  value: PresentationMode;
+  label: string;
+  description: string;
+}[] = [
+  {
+    value: 'single',
+    label: 'Single State',
+    description:
+      'Show one state at a time; scrub the timeline to move through the trace.'
+  },
+  {
+    value: 'window',
+    label: 'Sliding Window',
+    description:
+      'Show the state before, the current state, and the state after — side by side.'
+  },
+  {
+    value: 'compare',
+    label: 'Compare States',
+    description:
+      'Click states on the timeline to show any set of them side by side.'
+  }
+];
+
+// Shared style for the compare-mode quick-select buttons. Theme-aware tokens
+// (not Chakra grays) so it tracks light/dark like the rest of the panel.
+const HELPER_BUTTON =
+  'rounded-md border border-rule bg-surface-sunken px-2 py-1 text-xs font-medium text-ink-muted transition-colors hover:bg-surface-muted hover:text-ink';
 
 const TimePicker = ({ datum }: { datum: DatumParsed<any> }) => {
   const dispatch = useSterlingDispatch();
   const [isCollapsed, setIsCollapsed] = useState(false);
-  const [isMultiSelectMode, setIsMultiSelectMode] = useState(false);
 
+  const mode = useSterlingSelector((state) =>
+    selectPresentationMode(state, datum)
+  );
   const timeIndex = useSterlingSelector((state) =>
     selectTimeIndex(state, datum)
   );
@@ -27,131 +67,115 @@ const TimePicker = ({ datum }: { datum: DatumParsed<any> }) => {
   const loopBack = useSterlingSelector((state) =>
     selectLoopbackIndex(state, datum)
   );
-  const selectedTimeIndices = useSterlingSelector((state) =>
+  // The set of states actually on screen (drives the timeline highlight).
+  const effectiveIndices = useSterlingSelector((state) =>
+    selectEffectiveTimeIndices(state, datum)
+  );
+  // The stored compare set (only meaningful in compare mode).
+  const compareSet = useSterlingSelector((state) =>
     selectSelectedTimeIndices(state, datum)
   );
 
-  const indexSet = useCallback(
-    (index: number) => {
-      if (isMultiSelectMode) {
-        // In multi-select mode, toggle the index
-        dispatch(timeIndexToggled({ datum, index }));
-      } else {
-        // In single-select mode, set the time index normally
-        dispatch(timeIndexSet({ datum, index }));
-      }
-    },
-    [datum, dispatch, isMultiSelectMode]
+  const moveTo = useCallback(
+    (index: number) => dispatch(timeIndexSet({ datum, index })),
+    [dispatch, datum]
   );
 
-  const toggleMultiSelectMode = useCallback(() => {
-    const newMode = !isMultiSelectMode;
-    setIsMultiSelectMode(newMode);
-    
-    if (newMode) {
-      // Entering multi-select mode: initialize with current time index
-      dispatch(selectedTimeIndicesSet({ datum, selectedIndices: [timeIndex] }));
-    } else {
-      // Leaving multi-select mode: clear the multi-select state
-      dispatch(selectedTimeIndicesSet({ datum, selectedIndices: [] }));
-    }
-  }, [isMultiSelectMode, dispatch, datum, timeIndex]);
+  const toggleAt = useCallback(
+    (index: number) => dispatch(timeIndexToggled({ datum, index })),
+    [dispatch, datum]
+  );
 
-  const selectAllTimeIndices = useCallback(() => {
-    const allIndices = Array.from({ length: traceLength }, (_, i) => i);
-    dispatch(selectedTimeIndicesSet({ datum, selectedIndices: allIndices }));
-  }, [dispatch, datum, traceLength]);
+  const changeMode = useCallback(
+    (next: PresentationMode) => {
+      if (next === mode) return;
+      // Entering compare with no prior selection: seed it with the current
+      // state so there's something on screen and something to toggle off.
+      // A previous compare selection is preserved (we only seed when empty).
+      if (next === 'compare' && compareSet.length === 0) {
+        dispatch(
+          selectedTimeIndicesSet({ datum, selectedIndices: [timeIndex] })
+        );
+      }
+      dispatch(presentationModeSet({ datum, mode: next }));
+    },
+    [mode, compareSet.length, dispatch, datum, timeIndex]
+  );
 
   const selectFirstLast = useCallback(() => {
     const indices = traceLength > 1 ? [0, traceLength - 1] : [0];
     dispatch(selectedTimeIndicesSet({ datum, selectedIndices: indices }));
   }, [dispatch, datum, traceLength]);
 
+  const selectAll = useCallback(() => {
+    const indices = Array.from({ length: traceLength }, (_, i) => i);
+    dispatch(selectedTimeIndicesSet({ datum, selectedIndices: indices }));
+  }, [dispatch, datum, traceLength]);
+
+  const activeMode = MODE_OPTIONS.find((o) => o.value === mode);
+
   return (
-    <div className='mx-1 my-2'>
-      {/* Multi-select toggle for traces with multiple states */}
-      {traceLength > 1 && (
-        <div className="mb-2 flex items-center justify-between">
+    <div className='mx-1 my-2 flex flex-col gap-2'>
+      {/* Presentation-mode selector */}
+      <div>
+        <label
+          htmlFor='presentation-mode-select'
+          className='mb-1 block text-xs font-semibold uppercase tracking-wide text-ink-muted'
+        >
+          State Presentation
+        </label>
+        <select
+          id='presentation-mode-select'
+          value={mode}
+          onChange={(e) => changeMode(e.target.value as PresentationMode)}
+          className='w-full rounded border border-rule-strong bg-surface px-3 py-2 text-sm shadow-sm focus:border-accent-border focus:outline-none focus:ring-1 focus:ring-accent'
+        >
+          {MODE_OPTIONS.map((opt) => (
+            <option key={opt.value} value={opt.value}>
+              {opt.label}
+            </option>
+          ))}
+        </select>
+        <p className='mt-1 text-xs text-ink-faint'>{activeMode?.description}</p>
+      </div>
+
+      {/* Compare-only quick selectors */}
+      {mode === 'compare' && (
+        <div className='flex items-center gap-1'>
+          <span className='mr-1 text-xs text-ink-muted'>Quick select:</span>
           <button
-            type="button"
-            onClick={toggleMultiSelectMode}
-            className={`
-              px-2 py-1 text-xs rounded-md transition-all font-medium
-              ${isMultiSelectMode
-                ? 'bg-accent text-on-accent shadow-sm'
-                : 'bg-surface-sunken text-ink-muted hover:bg-surface-sunken border border-rule'
-              }
-            `}
+            type='button'
+            onClick={selectFirstLast}
+            className={HELPER_BUTTON}
           >
-            {isMultiSelectMode ? '✓ Compare Mode' : 'Compare States'}
+            First &amp; Last
           </button>
-          
-          {isMultiSelectMode && (
-            <div className="flex gap-1">
-              <button
-                type="button"
-                onClick={selectFirstLast}
-                className="px-2 py-1 text-xs rounded-md bg-surface-sunken text-ink-muted hover:bg-surface-sunken border border-rule"
-              >
-                First & Last
-              </button>
-              <button
-                type="button"
-                onClick={selectAllTimeIndices}
-                className="px-2 py-1 text-xs rounded-md bg-surface-sunken text-ink-muted hover:bg-surface-sunken border border-rule"
-              >
-                All
-              </button>
-            </div>
-          )}
+          <button type='button' onClick={selectAll} className={HELPER_BUTTON}>
+            All
+          </button>
         </div>
       )}
-      
-      {/* Multi-select time step buttons */}
-      {isMultiSelectMode && (
-        <div className="mb-2">
-          <p className="text-xs text-ink-muted mb-1.5">
-            Click states to compare side-by-side:
-          </p>
-          <div className="flex flex-wrap gap-1">
-            {Array.from({ length: traceLength }, (_, i) => {
-              const isSelected = selectedTimeIndices.includes(i);
-              return (
-                <button
-                  key={i}
-                  type="button"
-                  onClick={() => dispatch(timeIndexToggled({ datum, index: i }))}
-                  className={`
-                    w-8 h-8 text-xs rounded-md transition-all font-medium
-                    ${isSelected
-                      ? 'bg-accent text-on-accent shadow-sm'
-                      : 'bg-surface-sunken text-ink-muted hover:bg-surface-sunken border border-rule'
-                    }
-                  `}
-                >
-                  {i + 1}
-                </button>
-              );
-            })}
-          </div>
-          {selectedTimeIndices.length > 1 && (
-            <p className="text-xs text-accent mt-1.5 font-medium">
-              ✓ {selectedTimeIndices.length} states selected — showing side-by-side comparison
-            </p>
-          )}
-        </div>
-      )}
-      
-      {/* Original minimap (always visible for navigation) */}
+
+      {/* Shared timeline. Clicking a circle moves the current state, except in
+          compare mode where it toggles the state in/out of the comparison. */}
       <Minimap
         collapsed={isCollapsed}
         current={timeIndex}
         length={traceLength}
         loopBack={loopBack}
+        selectedIndices={effectiveIndices}
         label={(index) => `State ${index + 1}/${traceLength}`}
-        onChange={indexSet}
+        onChange={moveTo}
+        onNodeClick={mode === 'compare' ? toggleAt : moveTo}
         onToggleCollapse={() => setIsCollapsed((collapsed) => !collapsed)}
       />
+
+      {mode === 'compare' && compareSet.length > 1 && (
+        <p className='text-xs font-medium text-accent'>
+          ✓ {compareSet.length} states selected — showing side-by-side
+          comparison
+        </p>
+      )}
     </div>
   );
 };

--- a/packages/sterling/src/components/AppDrawer/graph/state/time/TimePicker.tsx
+++ b/packages/sterling/src/components/AppDrawer/graph/state/time/TimePicker.tsx
@@ -36,10 +36,11 @@ const TimePicker = ({ datum }: { datum: DatumParsed<any> }) => {
   const loopBack = useSterlingSelector((state) =>
     selectLoopbackIndex(state, datum)
   );
-  // The set of states actually on screen (drives the timeline highlight).
+  // The states actually on screen (drives the timeline highlight). Window mode
+  // can include null placeholder slots — drop them, only real states highlight.
   const effectiveIndices = useSterlingSelector((state) =>
     selectEffectiveTimeIndices(state, datum)
-  );
+  ).filter((i): i is number => i !== null);
   // The stored compare set (only meaningful in compare mode).
   const compareSet = useSterlingSelector((state) =>
     selectSelectedTimeIndices(state, datum)

--- a/packages/sterling/src/components/AppDrawer/graph/state/time/TimePicker.tsx
+++ b/packages/sterling/src/components/AppDrawer/graph/state/time/TimePicker.tsx
@@ -4,8 +4,7 @@ import type { PresentationMode } from '../../../../../state/graphs/graphs';
 import {
   presentationModeSet,
   selectedTimeIndicesSet,
-  timeIndexSet,
-  timeIndexToggled
+  timeIndexSet
 } from '../../../../../state/graphs/graphsSlice';
 import {
   useSterlingDispatch,
@@ -81,9 +80,24 @@ const TimePicker = ({ datum }: { datum: DatumParsed<any> }) => {
     [dispatch, datum]
   );
 
+  // Toggle a state in/out of the compare set. We compute the next set and
+  // dispatch it wholesale (rather than a toggle action) so the operation is
+  // idempotent: React StrictMode invokes the graph's click reducer twice in
+  // dev, and a true toggle would flip back to its starting state. Setting the
+  // same array twice is a no-op, so the click sticks. Always keep ≥1 selected.
   const toggleAt = useCallback(
-    (index: number) => dispatch(timeIndexToggled({ datum, index })),
-    [dispatch, datum]
+    (index: number) => {
+      const next = compareSet.includes(index)
+        ? compareSet.filter((i) => i !== index)
+        : [...compareSet, index].sort((a, b) => a - b);
+      dispatch(
+        selectedTimeIndicesSet({
+          datum,
+          selectedIndices: next.length > 0 ? next : compareSet
+        })
+      );
+    },
+    [dispatch, datum, compareSet]
   );
 
   const changeMode = useCallback(

--- a/packages/sterling/src/components/AppDrawer/graph/state/time/TimePicker.tsx
+++ b/packages/sterling/src/components/AppDrawer/graph/state/time/TimePicker.tsx
@@ -107,7 +107,7 @@ const TimePicker = ({ datum }: { datum: DatumParsed<any> }) => {
         length={traceLength}
         loopBack={loopBack}
         selectedIndices={effectiveIndices}
-        label={(index) => `State ${index + 1}/${traceLength}`}
+        label={(index) => `State ${index}/${traceLength}`}
         onChange={moveTo}
         onNodeClick={mode === 'compare' ? toggleAt : moveTo}
         onToggleCollapse={() => setIsCollapsed((collapsed) => !collapsed)}

--- a/packages/sterling/src/components/AppDrawer/graph/state/time/TimePicker.tsx
+++ b/packages/sterling/src/components/AppDrawer/graph/state/time/TimePicker.tsx
@@ -1,11 +1,6 @@
 import { DatumParsed } from '@/sterling-connection';
 import { useCallback, useState } from 'react';
-import type { PresentationMode } from '../../../../../state/graphs/graphs';
-import {
-  presentationModeSet,
-  selectedTimeIndicesSet,
-  timeIndexSet
-} from '../../../../../state/graphs/graphsSlice';
+import { selectedTimeIndicesSet, timeIndexSet } from '../../../../../state/graphs/graphsSlice';
 import {
   useSterlingDispatch,
   useSterlingSelector
@@ -19,31 +14,6 @@ import {
   selectTraceLength
 } from '../../../../../state/selectors';
 import { Minimap } from '../../../../Minimap/Minimap';
-
-const MODE_OPTIONS: {
-  value: PresentationMode;
-  label: string;
-  description: string;
-}[] = [
-  {
-    value: 'single',
-    label: 'Single State',
-    description:
-      'Show one state at a time; scrub the timeline to move through the trace.'
-  },
-  {
-    value: 'window',
-    label: 'Sliding Window',
-    description:
-      'Show the state before, the current state, and the state after — side by side.'
-  },
-  {
-    value: 'compare',
-    label: 'Compare States',
-    description:
-      'Click states on the timeline to show any set of them side by side.'
-  }
-];
 
 // Shared style for the compare-mode quick-select buttons. Theme-aware tokens
 // (not Chakra grays) so it tracks light/dark like the rest of the panel.
@@ -100,22 +70,6 @@ const TimePicker = ({ datum }: { datum: DatumParsed<any> }) => {
     [dispatch, datum, compareSet]
   );
 
-  const changeMode = useCallback(
-    (next: PresentationMode) => {
-      if (next === mode) return;
-      // Entering compare with no prior selection: seed it with the current
-      // state so there's something on screen and something to toggle off.
-      // A previous compare selection is preserved (we only seed when empty).
-      if (next === 'compare' && compareSet.length === 0) {
-        dispatch(
-          selectedTimeIndicesSet({ datum, selectedIndices: [timeIndex] })
-        );
-      }
-      dispatch(presentationModeSet({ datum, mode: next }));
-    },
-    [mode, compareSet.length, dispatch, datum, timeIndex]
-  );
-
   const selectFirstLast = useCallback(() => {
     const indices = traceLength > 1 ? [0, traceLength - 1] : [0];
     dispatch(selectedTimeIndicesSet({ datum, selectedIndices: indices }));
@@ -126,36 +80,11 @@ const TimePicker = ({ datum }: { datum: DatumParsed<any> }) => {
     dispatch(selectedTimeIndicesSet({ datum, selectedIndices: indices }));
   }, [dispatch, datum, traceLength]);
 
-  const activeMode = MODE_OPTIONS.find((o) => o.value === mode);
-
   return (
     <div className='mx-1 my-2 flex flex-col gap-2'>
-      {/* Presentation-mode selector */}
-      <div>
-        <label
-          htmlFor='presentation-mode-select'
-          className='mb-1 block text-xs font-semibold uppercase tracking-wide text-ink-muted'
-        >
-          State Presentation
-        </label>
-        <select
-          id='presentation-mode-select'
-          value={mode}
-          onChange={(e) => changeMode(e.target.value as PresentationMode)}
-          className='w-full rounded border border-rule-strong bg-surface px-3 py-2 text-sm shadow-sm focus:border-accent-border focus:outline-none focus:ring-1 focus:ring-accent'
-        >
-          {MODE_OPTIONS.map((opt) => (
-            <option key={opt.value} value={opt.value}>
-              {opt.label}
-            </option>
-          ))}
-        </select>
-        <p className='mt-1 text-xs text-ink-faint'>{activeMode?.description}</p>
-      </div>
-
       {/* Compare-only quick selectors */}
       {mode === 'compare' && (
-        <div className='flex items-center gap-1'>
+        <div className='flex items-center gap-1 px-1'>
           <span className='mr-1 text-xs text-ink-muted'>Quick select:</span>
           <button
             type='button'
@@ -185,9 +114,8 @@ const TimePicker = ({ datum }: { datum: DatumParsed<any> }) => {
       />
 
       {mode === 'compare' && compareSet.length > 1 && (
-        <p className='text-xs font-medium text-accent'>
+        <p className='px-1 text-xs font-medium text-accent'>
           ✓ {compareSet.length} states selected — showing side-by-side
-          comparison
         </p>
       )}
     </div>

--- a/packages/sterling/src/components/AppNavBar/AppNavBar.tsx
+++ b/packages/sterling/src/components/AppNavBar/AppNavBar.tsx
@@ -1,6 +1,7 @@
 import { NavBar } from '@/sterling-ui';
 import { Spacer } from '@chakra-ui/react';
 import { NavConnection } from './NavConnection';
+import { NavDatumInfo } from './NavDatumInfo';
 import { OverflowMenu } from './OverflowMenu';
 import { PanelToggle } from './PanelToggle';
 import { ThemeToggle } from './ThemeToggle';
@@ -10,6 +11,7 @@ const AppNavBar = () => {
   return (
     <NavBar className='shadow'>
       <ViewMenu />
+      <NavDatumInfo />
       <Spacer />
       <NavConnection />
       <PanelToggle />

--- a/packages/sterling/src/components/AppNavBar/NavDatumInfo.tsx
+++ b/packages/sterling/src/components/AppNavBar/NavDatumInfo.tsx
@@ -1,0 +1,29 @@
+import { useSterlingSelector } from '../../state/hooks';
+import { selectActiveDatum, selectMainView } from '../../state/selectors';
+
+// Shows the active instance's ID (and command) in the top bar, alongside the
+// Graph / Control Panel controls, instead of in a separate strip above the
+// graph. Graph view only — other views keep their own headers.
+const NavDatumInfo = () => {
+  const mainView = useSterlingSelector(selectMainView);
+  const datum = useSterlingSelector(selectActiveDatum);
+
+  if (mainView !== 'GraphView' || !datum) return null;
+
+  const command = datum.parsed?.command;
+
+  return (
+    <div className='flex min-w-0 max-w-[40vw] items-center gap-2 text-xs'>
+      <span className='truncate text-ink-faint' title={datum.id}>
+        ID: {datum.id}
+      </span>
+      {command && (
+        <span className='truncate text-ink-muted' title={command}>
+          {command}
+        </span>
+      )}
+    </div>
+  );
+};
+
+export { NavDatumInfo };

--- a/packages/sterling/src/components/AppNavBar/PanelToggle.tsx
+++ b/packages/sterling/src/components/AppNavBar/PanelToggle.tsx
@@ -25,7 +25,7 @@ const PanelToggle = () => {
     }
   };
 
-  const label = collapsed ? 'Show panel' : 'Hide panel';
+  const label = collapsed ? 'Show control panel' : 'Hide control panel';
   return (
     <Button
       aria-label={label}
@@ -35,7 +35,7 @@ const PanelToggle = () => {
       variant='ghost'
       onClick={toggle}
     >
-      Panel
+      Control Panel
     </Button>
   );
 };

--- a/packages/sterling/src/components/GraphView/GraphView.tsx
+++ b/packages/sterling/src/components/GraphView/GraphView.tsx
@@ -328,10 +328,20 @@ const GraphView = () => {
       {datum ? (
         <div className='relative'>
           <Pane>
-            <PaneHeader className='border-b'>
-              <GraphViewHeader datum={datum} />
-            </PaneHeader>
-            <PaneBody display="flex" flexDirection="column">
+            {/* The ID/command moved to the top nav bar (NavDatumInfo); only
+                render this header strip when the provider has action buttons.
+                When absent, pull the body up to top:0 so no empty gap is left
+                (PaneBody is absolutely positioned below the header by default). */}
+            {datum.buttons && datum.buttons.length > 0 && (
+              <PaneHeader className='border-b'>
+                <GraphViewHeader datum={datum} />
+              </PaneHeader>
+            )}
+            <PaneBody
+              display="flex"
+              flexDirection="column"
+              top={datum.buttons && datum.buttons.length > 0 ? undefined : '0px'}
+            >
               {/* SpyTial error modal mounts here — sits above the graph and
                   collapses to nothing when there is no active error. */}
               <div

--- a/packages/sterling/src/components/GraphView/GraphView.tsx
+++ b/packages/sterling/src/components/GraphView/GraphView.tsx
@@ -10,6 +10,7 @@ import {
   selectSynthesisStep,
   selectSelectedProjections,
   selectEffectiveTimeIndices,
+  selectPresentationMode,
   selectTraceLength,
   selectProjectionConfig,
   selectSequencePolicyName
@@ -70,6 +71,9 @@ const GraphView = () => {
   // mode (single -> [current]; window -> before/current/after; compare -> set).
   const effectiveTimeIndices = useSterlingSelector((state) =>
     datum ? selectEffectiveTimeIndices(state, datum) : []
+  );
+  const presentationMode = useSterlingSelector((state) =>
+    datum ? selectPresentationMode(state, datum) : 'single'
   );
 
   // CND-derived projection config and sequence policy
@@ -281,6 +285,7 @@ const GraphView = () => {
           selectedTimeIndices={effectiveTimeIndices}
           traceLength={traceLength}
           sequencePolicyName={sequencePolicyName}
+          anchorTimeIndex={presentationMode === 'window' ? timeIndex : undefined}
         />
       );
     }

--- a/packages/sterling/src/components/GraphView/GraphView.tsx
+++ b/packages/sterling/src/components/GraphView/GraphView.tsx
@@ -11,6 +11,7 @@ import {
   selectSelectedProjections,
   selectEffectiveTimeIndices,
   selectPresentationMode,
+  selectComparisonLayout,
   selectTraceLength,
   selectProjectionConfig,
   selectSequencePolicyName
@@ -74,6 +75,9 @@ const GraphView = () => {
   );
   const presentationMode = useSterlingSelector((state) =>
     datum ? selectPresentationMode(state, datum) : 'single'
+  );
+  const comparisonLayout = useSterlingSelector((state) =>
+    datum ? selectComparisonLayout(state, datum) : 'horizontal'
   );
 
   // CND-derived projection config and sequence policy
@@ -286,6 +290,7 @@ const GraphView = () => {
           traceLength={traceLength}
           sequencePolicyName={sequencePolicyName}
           anchorTimeIndex={presentationMode === 'window' ? timeIndex : undefined}
+          layout={comparisonLayout}
         />
       );
     }

--- a/packages/sterling/src/components/GraphView/GraphView.tsx
+++ b/packages/sterling/src/components/GraphView/GraphView.tsx
@@ -9,7 +9,7 @@ import {
   selectIsSynthesisActive,
   selectSynthesisStep,
   selectSelectedProjections,
-  selectSelectedTimeIndices,
+  selectEffectiveTimeIndices,
   selectTraceLength,
   selectProjectionConfig,
   selectSequencePolicyName
@@ -66,9 +66,10 @@ const GraphView = () => {
     datum ? selectSelectedProjections(state, datum) : {}
   );
   
-  // Selected time indices for multi-temporal view
-  const selectedTimeIndices = useSterlingSelector((state) =>
-    datum ? selectSelectedTimeIndices(state, datum) : []
+  // Effective time indices to render, derived from the datum's presentation
+  // mode (single -> [current]; window -> before/current/after; compare -> set).
+  const effectiveTimeIndices = useSterlingSelector((state) =>
+    datum ? selectEffectiveTimeIndices(state, datum) : []
   );
 
   // CND-derived projection config and sequence policy
@@ -110,8 +111,9 @@ const GraphView = () => {
     return null;
   }, [selectedProjections]);
   
-  // Check if multi-temporal mode is active (more than 1 time index selected)
-  const isMultiTemporalActive = selectedTimeIndices.length > 1;
+  // Multi-temporal (side-by-side) rendering kicks in whenever the effective
+  // set has more than one state — i.e. window mode, or compare with 2+ states.
+  const isMultiTemporalActive = effectiveTimeIndices.length > 1;
 
   // Build a Record<string, string> of single-atom selections for applyProjectionTransform
   // (uses the first selected atom per projection type)
@@ -276,7 +278,7 @@ const GraphView = () => {
         <MultiTemporalGraph
           datum={datum}
           cndSpec={cndSpec}
-          selectedTimeIndices={selectedTimeIndices}
+          selectedTimeIndices={effectiveTimeIndices}
           traceLength={traceLength}
           sequencePolicyName={sequencePolicyName}
         />

--- a/packages/sterling/src/components/GraphView/GraphViewHeader.tsx
+++ b/packages/sterling/src/components/GraphView/GraphViewHeader.tsx
@@ -1,21 +1,19 @@
 import { Button, DatumParsed } from '@/sterling-connection';
-import { PaneTitle } from '@/sterling-ui';
-import { GraphData } from '../../state/graphs/graphs';
 import { GraphViewHeaderButton } from './GraphViewHeaderButton';
 
 interface GraphViewHeaderProps {
   datum: DatumParsed<any>;
 }
 
+// The instance ID and command now live in the top nav bar (see NavDatumInfo);
+// this header only carries the provider's action buttons, and is rendered by
+// GraphView only when there are buttons to show.
 const GraphViewHeader = (props: GraphViewHeaderProps) => {
   const { datum } = props;
-  const { id, parsed, buttons, generatorName } = datum;
-  const command = parsed.command;
+  const { id, buttons, generatorName } = datum;
 
   return (
-    <div className='w-full flex item-center space-x-2 px-2'>
-      <PaneTitle className='text-ink-faint'>ID: {id}</PaneTitle>
-      <PaneTitle>{command}</PaneTitle>
+    <div className='w-full flex items-center space-x-2 px-2'>
       <div className='grow' />
       {buttons &&
         buttons.map((button: Button, index: number) => {

--- a/packages/sterling/src/components/GraphView/MultiTemporalGraph.tsx
+++ b/packages/sterling/src/components/GraphView/MultiTemporalGraph.tsx
@@ -4,6 +4,7 @@ import { parseCndFile, SequencePolicyName } from '../../utils/cndPreParser';
 import { getSpytialCore, hasSpytialCore } from '../../utils/spytialCore';
 import { useSterlingSelector } from '../../state/hooks';
 import { selectColorMode } from '../../state/selectors';
+import type { LayoutState } from './SpyTialGraph';
 
 /**
  * The signature label that Forge uses to indicate no more instances are available.
@@ -35,6 +36,13 @@ interface MultiTemporalGraphProps {
   traceLength: number;
   /** Sequence policy name from CND spec */
   sequencePolicyName?: SequencePolicyName;
+  /**
+   * The current/anchor state index. When set (sliding-window mode), the other
+   * panes apply the temporal policy relative to this state's layout so matching
+   * nodes stay in place across the window. Undefined (compare mode) means every
+   * pane is laid out independently.
+   */
+  anchorTimeIndex?: number;
 }
 
 interface SingleTemporalPaneProps {
@@ -45,17 +53,46 @@ interface SingleTemporalPaneProps {
   index: number;
   /** Sequence policy name from CND spec */
   sequencePolicyName?: SequencePolicyName;
+  /** Apply the temporal policy, morphing this pane toward `priorState`. */
+  applyContinuity?: boolean;
+  /** The anchor (current) state's layout positions to continue from. */
+  priorState?: LayoutState;
+  /** The anchor state's trace index, used to build the policy's prevInstance. */
+  prevTimeIndex?: number;
+  /** Defer rendering until the anchor has reported its layout. */
+  waitingForAnchor?: boolean;
+  /** Anchor pane only: report its settled layout (or null on failure). */
+  onLayoutStateChange?: (state: LayoutState | null) => void;
 }
 
 /**
  * A single pane showing one time step
  */
 const SingleTemporalPane = (props: SingleTemporalPaneProps) => {
-  const { datum, cndSpec, timeIndex, traceLength, index, sequencePolicyName = 'stability' } = props;
+  const {
+    datum,
+    cndSpec,
+    timeIndex,
+    traceLength,
+    index,
+    sequencePolicyName = 'stability',
+    applyContinuity = false,
+    priorState,
+    prevTimeIndex,
+    waitingForAnchor = false,
+    onLayoutStateChange
+  } = props;
 
   const colorMode = useSterlingSelector(selectColorMode);
   const colorModeRef = useRef(colorMode);
   colorModeRef.current = colorMode;
+  // Keep the report callback in a ref so loadGraph doesn't re-run when the
+  // parent passes a fresh closure each render.
+  const onLayoutStateChangeRef = useRef(onLayoutStateChange);
+  onLayoutStateChangeRef.current = onLayoutStateChange;
+  // Whether the anchor's settled positions have been reported for the current
+  // render (set by the 'layout-complete' event; gates the timeout fallback).
+  const anchorSettledRef = useRef(false);
   const graphContainerRef = useRef<HTMLDivElement>(null);
   const graphElementRef = useRef<HTMLElementTagNameMap['webcola-cnd-graph'] | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -68,7 +105,15 @@ const SingleTemporalPane = (props: SingleTemporalPaneProps) => {
    */
   const loadGraph = useCallback(async () => {
     if (!graphElementRef.current) return;
-    
+
+    // Non-anchor panes hold (showing the loading overlay) until the anchor has
+    // reported its layout, so they can morph toward it rather than flashing an
+    // independent layout first.
+    if (waitingForAnchor) {
+      setIsLoading(true);
+      return;
+    }
+
     setIsLoading(true);
     setError(null);
 
@@ -145,11 +190,67 @@ const SingleTemporalPane = (props: SingleTemporalPaneProps) => {
           graphElementRef.current.clear();
         }
         graphElementRef.current.setTheme?.(colorModeRef.current);
-        await graphElementRef.current.renderLayout(layoutResult.layout);
+
+        // In sliding-window mode the non-anchor panes morph toward the anchor
+        // (current) state's positions via the sequence policy, so matching
+        // nodes stay put across the window. Mirrors SpyTialGraph's single-state
+        // continuity. Compare mode passes no continuity and lays out freely.
+        const renderOptions: any = {};
+        const hasPrior =
+          applyContinuity &&
+          priorState &&
+          priorState.positions &&
+          priorState.positions.length > 0;
+        if (hasPrior && sequencePolicyName && sequencePolicyName !== 'ignore_history') {
+          try {
+            const policy = core.getSequencePolicy?.(sequencePolicyName);
+            if (policy) {
+              renderOptions.policy = policy;
+              renderOptions.currInstance = alloyDataInstance;
+              renderOptions.priorPositions = priorState;
+              if (prevTimeIndex !== undefined) {
+                const prevIdx = Math.min(prevTimeIndex, alloyDatum.instances.length - 1);
+                renderOptions.prevInstance = new core.AlloyDataInstance(alloyDatum.instances[prevIdx]);
+              }
+            } else {
+              renderOptions.priorPositions = priorState;
+            }
+          } catch (err) {
+            console.warn('[MultiTemporalGraph] Failed to get sequence policy:', err);
+            renderOptions.priorPositions = priorState;
+          }
+        }
+
+        // Anchor pane: arm settled-position reporting before rendering. The
+        // 'layout-complete' listener (added at element creation) captures the
+        // positions AFTER WebCola settles — capturing right after renderLayout
+        // resolves would hand followers pre-settle positions.
+        if (onLayoutStateChangeRef.current) {
+          anchorSettledRef.current = false;
+        }
+
+        await graphElementRef.current.renderLayout(
+          layoutResult.layout,
+          Object.keys(renderOptions).length > 0 ? renderOptions : undefined
+        );
         // Re-fit the viewport to this time step's content. The graph otherwise
         // keeps the prior viewport once the user has zoomed/panned, leaving the
         // step framed by a stale view. (See SpyTialGraph for the full rationale.)
         graphElementRef.current.resetViewToFitContent?.();
+
+        // Fallback: if 'layout-complete' never fires, still report (slightly
+        // pre-settle) positions so followers don't wait forever.
+        if (onLayoutStateChangeRef.current) {
+          const el = graphElementRef.current;
+          setTimeout(() => {
+            if (!anchorSettledRef.current && onLayoutStateChangeRef.current && el?.getLayoutState) {
+              const s = el.getLayoutState();
+              onLayoutStateChangeRef.current(
+                s && s.positions && s.positions.length > 0 ? s : null
+              );
+            }
+          }, 1500);
+        }
       }
 
       setIsLoading(false);
@@ -157,11 +258,24 @@ const SingleTemporalPane = (props: SingleTemporalPaneProps) => {
       console.error(`[Time ${timeIndex}] Error rendering graph:`, err);
       setError(`Error: ${err.message}`);
       setIsLoading(false);
+      // If the anchor fails, unblock the other panes so they render without
+      // continuity rather than waiting on a layout that will never arrive.
+      onLayoutStateChangeRef.current?.(null);
     }
     // colorMode is intentionally NOT a dependency: theme switches re-tint in
     // place via setTheme (effect below) — a full clear()+renderLayout here
     // races spytial-core's WebCola ticks against nulled selections.
-  }, [datum.data, datum.id, cndSpec, timeIndex, sequencePolicyName]);
+  }, [
+    datum.data,
+    datum.id,
+    cndSpec,
+    timeIndex,
+    sequencePolicyName,
+    applyContinuity,
+    priorState,
+    prevTimeIndex,
+    waitingForAnchor
+  ]);
 
   // Create and mount the webcola-cnd-graph element once.
   // useLayoutEffect so the cleanup detaches the element synchronously, ahead of
@@ -186,7 +300,21 @@ const SingleTemporalPane = (props: SingleTemporalPaneProps) => {
     graphElementRef.current = graphElement;
     isInitializedRef.current = true;
 
+    // Anchor pane only (others leave onLayoutStateChange undefined): capture the
+    // FINAL positions once WebCola settles and hand them to the follower panes.
+    const handleLayoutComplete = () => {
+      if (onLayoutStateChangeRef.current && graphElementRef.current?.getLayoutState) {
+        const s = graphElementRef.current.getLayoutState();
+        if (s && s.positions && s.positions.length > 0) {
+          anchorSettledRef.current = true;
+          onLayoutStateChangeRef.current(s);
+        }
+      }
+    };
+    graphElement.addEventListener('layout-complete', handleLayoutComplete as EventListener);
+
     return () => {
+      graphElement.removeEventListener('layout-complete', handleLayoutComplete as EventListener);
       if (graphElementRef.current) {
         graphElementRef.current.clear?.();
         graphElementRef.current.remove();
@@ -252,10 +380,37 @@ const SingleTemporalPane = (props: SingleTemporalPaneProps) => {
  * Component that renders multiple graphs in a grid, one for each selected time step
  */
 const MultiTemporalGraph = (props: MultiTemporalGraphProps) => {
-  const { datum, cndSpec, selectedTimeIndices, traceLength, sequencePolicyName } = props;
-  
+  const { datum, cndSpec, selectedTimeIndices, traceLength, sequencePolicyName, anchorTimeIndex } = props;
+
   const [isCndCoreReady, setIsCndCoreReady] = useState(hasSpytialCore());
   const [error, setError] = useState<string | null>(null);
+
+  // Sliding-window continuity: the pane for `anchorTimeIndex` (the current
+  // state) lays out fresh and reports its positions; the others wait for it and
+  // morph toward it via the temporal policy. Only active when an anchor is
+  // present, a real policy is set, and the anchor is one of the shown panes
+  // (compare mode passes no anchor, so panes stay independent).
+  const continuityActive =
+    anchorTimeIndex !== undefined &&
+    !!sequencePolicyName &&
+    sequencePolicyName !== 'ignore_history' &&
+    selectedTimeIndices.includes(anchorTimeIndex);
+
+  const [anchorResult, setAnchorResult] = useState<{
+    resolved: boolean;
+    state: LayoutState | null;
+  }>({ resolved: false, state: null });
+  const reportAnchor = useCallback(
+    (state: LayoutState | null) => setAnchorResult({ resolved: true, state }),
+    []
+  );
+
+  // Re-anchor whenever the window, policy, or spec changes (e.g. scrubbing
+  // shifts the window) so panes never continue from stale positions.
+  const windowKey = `${datum.id}|${cndSpec}|${sequencePolicyName ?? ''}|${anchorTimeIndex ?? ''}|${selectedTimeIndices.join(',')}`;
+  useEffect(() => {
+    setAnchorResult({ resolved: false, state: null });
+  }, [windowKey]);
 
   // Poll for CndCore availability
   useEffect(() => {
@@ -340,17 +495,26 @@ const MultiTemporalGraph = (props: MultiTemporalGraphProps) => {
           gridTemplateColumns: `repeat(${gridCols}, minmax(300px, 1fr))`,
         }}
       >
-        {selectedTimeIndices.map((timeIdx, index) => (
-          <SingleTemporalPane
-            key={`time-${timeIdx}`}
-            datum={datum}
-            cndSpec={cndSpec}
-            timeIndex={timeIdx}
-            traceLength={traceLength}
-            index={index}
-            sequencePolicyName={sequencePolicyName}
-          />
-        ))}
+        {selectedTimeIndices.map((timeIdx, index) => {
+          const isAnchor = continuityActive && timeIdx === anchorTimeIndex;
+          const isFollower = continuityActive && !isAnchor;
+          return (
+            <SingleTemporalPane
+              key={`time-${timeIdx}`}
+              datum={datum}
+              cndSpec={cndSpec}
+              timeIndex={timeIdx}
+              traceLength={traceLength}
+              index={index}
+              sequencePolicyName={sequencePolicyName}
+              applyContinuity={isFollower}
+              priorState={isFollower ? anchorResult.state ?? undefined : undefined}
+              prevTimeIndex={isFollower ? anchorTimeIndex : undefined}
+              waitingForAnchor={isFollower && !anchorResult.resolved}
+              onLayoutStateChange={isAnchor ? reportAnchor : undefined}
+            />
+          );
+        })}
       </div>
     </div>
   );

--- a/packages/sterling/src/components/GraphView/MultiTemporalGraph.tsx
+++ b/packages/sterling/src/components/GraphView/MultiTemporalGraph.tsx
@@ -479,19 +479,13 @@ const MultiTemporalGraph = (props: MultiTemporalGraphProps) => {
   }
 
   return (
-    <div className="absolute inset-0 overflow-auto bg-surface-sunken p-4">
-      <div className="mb-4 px-2">
-        <h2 className="text-lg font-semibold text-ink">
-          Temporal Comparison
-        </h2>
-        <p className="text-sm text-ink-muted">
-          Showing {selectedTimeIndices.length} time step{selectedTimeIndices.length !== 1 ? 's' : ''} of {traceLength}
-        </p>
-      </div>
-      
-      <div 
+    <div className="absolute inset-0 overflow-auto bg-surface-sunken p-3">
+      {/* No header here — each pane already labels its own "State N of M", so a
+          "Temporal Comparison / Showing N of M" banner is redundant and just
+          eats vertical space. */}
+      <div
         className="grid gap-4"
-        style={{ 
+        style={{
           gridTemplateColumns: `repeat(${gridCols}, minmax(300px, 1fr))`,
         }}
       >

--- a/packages/sterling/src/components/GraphView/MultiTemporalGraph.tsx
+++ b/packages/sterling/src/components/GraphView/MultiTemporalGraph.tsx
@@ -266,7 +266,7 @@ const SingleTemporalPane = (props: SingleTemporalPaneProps) => {
             'font-size:12px;font-weight:600;padding:0 8px;white-space:nowrap;display:flex;align-items:center;color:var(--ccd-ink-muted,#64748b);';
           labelRef.current = lbl;
         }
-        labelRef.current.textContent = `State ${timeIndex + 1} of ${traceLength}`;
+        labelRef.current.textContent = `State ${timeIndex} of ${traceLength}`;
         const toolbar = el.shadowRoot?.querySelector('#graph-toolbar');
         if (toolbar) {
           toolbar.insertBefore(labelRef.current, toolbar.firstChild);
@@ -323,7 +323,7 @@ const SingleTemporalPane = (props: SingleTemporalPaneProps) => {
     const graphElement = document.createElement('webcola-cnd-graph') as HTMLElementTagNameMap['webcola-cnd-graph'];
     graphElement.id = `spytial-graph-temporal-${index}`;
     graphElement.setAttribute('layoutFormat', 'default');
-    graphElement.setAttribute('aria-label', `Graph visualization for time step ${timeIndex + 1}`);
+    graphElement.setAttribute('aria-label', `Graph visualization for state ${timeIndex}`);
     graphElement.setAttribute('theme', colorModeRef.current);
     graphElement.style.cssText = `
       width: 100%;

--- a/packages/sterling/src/components/GraphView/MultiTemporalGraph.tsx
+++ b/packages/sterling/src/components/GraphView/MultiTemporalGraph.tsx
@@ -93,6 +93,10 @@ const SingleTemporalPane = (props: SingleTemporalPaneProps) => {
   // Whether the anchor's settled positions have been reported for the current
   // render (set by the 'layout-complete' event; gates the timeout fallback).
   const anchorSettledRef = useRef(false);
+  // The "State N of M" label, hosted inside the graph's own toolbar (rather
+  // than a separate header strip) to save vertical space. One persistent node:
+  // re-adding it just moves it, so it never duplicates across re-renders.
+  const labelRef = useRef<HTMLDivElement | null>(null);
   const graphContainerRef = useRef<HTMLDivElement>(null);
   const graphElementRef = useRef<HTMLElementTagNameMap['webcola-cnd-graph'] | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -238,6 +242,25 @@ const SingleTemporalPane = (props: SingleTemporalPaneProps) => {
         // step framed by a stale view. (See SpyTialGraph for the full rationale.)
         graphElementRef.current.resetViewToFitContent?.();
 
+        // Host the "State N of M" label inside the graph's own toolbar to save
+        // the vertical space a separate header strip would take. Prepend it so
+        // it stays visible when the toolbar overflows a narrow pane (the public
+        // addToolbarControl only appends, where it gets clipped). Re-inserting
+        // the same node just moves it, so it never duplicates.
+        if (!labelRef.current) {
+          const el = document.createElement('div');
+          el.style.cssText =
+            'font-size:12px;font-weight:600;padding:0 8px;white-space:nowrap;display:flex;align-items:center;color:var(--ccd-ink-muted,#64748b);';
+          labelRef.current = el;
+        }
+        labelRef.current.textContent = `State ${timeIndex + 1} of ${traceLength}`;
+        const toolbar = graphElementRef.current.shadowRoot?.querySelector('#graph-toolbar');
+        if (toolbar) {
+          toolbar.insertBefore(labelRef.current, toolbar.firstChild);
+        } else {
+          graphElementRef.current.addToolbarControl?.(labelRef.current);
+        }
+
         // Fallback: if 'layout-complete' never fires, still report (slightly
         // pre-settle) positions so followers don't wait forever.
         if (onLayoutStateChangeRef.current) {
@@ -270,6 +293,7 @@ const SingleTemporalPane = (props: SingleTemporalPaneProps) => {
     datum.id,
     cndSpec,
     timeIndex,
+    traceLength,
     sequencePolicyName,
     applyContinuity,
     priorState,
@@ -339,12 +363,8 @@ const SingleTemporalPane = (props: SingleTemporalPaneProps) => {
 
   return (
     <div className="relative flex flex-col border border-rule-strong rounded-lg overflow-hidden bg-surface shadow-sm">
-      {/* Header with time step label */}
-      <div className="px-3 py-2 bg-info-bg border-b border-info-border">
-        <span className="font-medium text-sm text-info">
-          State {timeIndex + 1} of {traceLength}
-        </span>
-      </div>
+      {/* The "State N of M" label is injected into the graph's own toolbar
+          (see loadGraph) instead of a separate header strip, to save space. */}
 
       {/* Graph container */}
       <div

--- a/packages/sterling/src/components/GraphView/MultiTemporalGraph.tsx
+++ b/packages/sterling/src/components/GraphView/MultiTemporalGraph.tsx
@@ -5,6 +5,7 @@ import { getSpytialCore, hasSpytialCore } from '../../utils/spytialCore';
 import { useSterlingSelector } from '../../state/hooks';
 import { selectColorMode } from '../../state/selectors';
 import type { LayoutState } from './SpyTialGraph';
+import type { ComparisonLayout } from '../../state/graphs/graphs';
 
 /**
  * The signature label that Forge uses to indicate no more instances are available.
@@ -43,6 +44,8 @@ interface MultiTemporalGraphProps {
    * pane is laid out independently.
    */
   anchorTimeIndex?: number;
+  /** Flow direction for the panes: 'horizontal' (grid) or 'vertical' (column). */
+  layout?: ComparisonLayout;
 }
 
 interface SingleTemporalPaneProps {
@@ -237,10 +240,20 @@ const SingleTemporalPane = (props: SingleTemporalPaneProps) => {
           layoutResult.layout,
           Object.keys(renderOptions).length > 0 ? renderOptions : undefined
         );
+
+        // The pane can unmount/remount during the await (e.g. rapid scrubbing
+        // shifts the window), nulling the ref. Bail if so — a fresh loadGraph
+        // runs for the new element — rather than dereferencing null below.
+        const el = graphElementRef.current;
+        if (!el) {
+          setIsLoading(false);
+          return;
+        }
+
         // Re-fit the viewport to this time step's content. The graph otherwise
         // keeps the prior viewport once the user has zoomed/panned, leaving the
         // step framed by a stale view. (See SpyTialGraph for the full rationale.)
-        graphElementRef.current.resetViewToFitContent?.();
+        el.resetViewToFitContent?.();
 
         // Host the "State N of M" label inside the graph's own toolbar to save
         // the vertical space a separate header strip would take. Prepend it so
@@ -248,23 +261,22 @@ const SingleTemporalPane = (props: SingleTemporalPaneProps) => {
         // addToolbarControl only appends, where it gets clipped). Re-inserting
         // the same node just moves it, so it never duplicates.
         if (!labelRef.current) {
-          const el = document.createElement('div');
-          el.style.cssText =
+          const lbl = document.createElement('div');
+          lbl.style.cssText =
             'font-size:12px;font-weight:600;padding:0 8px;white-space:nowrap;display:flex;align-items:center;color:var(--ccd-ink-muted,#64748b);';
-          labelRef.current = el;
+          labelRef.current = lbl;
         }
         labelRef.current.textContent = `State ${timeIndex + 1} of ${traceLength}`;
-        const toolbar = graphElementRef.current.shadowRoot?.querySelector('#graph-toolbar');
+        const toolbar = el.shadowRoot?.querySelector('#graph-toolbar');
         if (toolbar) {
           toolbar.insertBefore(labelRef.current, toolbar.firstChild);
         } else {
-          graphElementRef.current.addToolbarControl?.(labelRef.current);
+          el.addToolbarControl?.(labelRef.current);
         }
 
         // Fallback: if 'layout-complete' never fires, still report (slightly
         // pre-settle) positions so followers don't wait forever.
         if (onLayoutStateChangeRef.current) {
-          const el = graphElementRef.current;
           setTimeout(() => {
             if (!anchorSettledRef.current && onLayoutStateChangeRef.current && el?.getLayoutState) {
               const s = el.getLayoutState();
@@ -400,7 +412,7 @@ const SingleTemporalPane = (props: SingleTemporalPaneProps) => {
  * Component that renders multiple graphs in a grid, one for each selected time step
  */
 const MultiTemporalGraph = (props: MultiTemporalGraphProps) => {
-  const { datum, cndSpec, selectedTimeIndices, traceLength, sequencePolicyName, anchorTimeIndex } = props;
+  const { datum, cndSpec, selectedTimeIndices, traceLength, sequencePolicyName, anchorTimeIndex, layout = 'horizontal' } = props;
 
   const [isCndCoreReady, setIsCndCoreReady] = useState(hasSpytialCore());
   const [error, setError] = useState<string | null>(null);
@@ -506,7 +518,12 @@ const MultiTemporalGraph = (props: MultiTemporalGraphProps) => {
       <div
         className="grid gap-4"
         style={{
-          gridTemplateColumns: `repeat(${gridCols}, minmax(300px, 1fr))`,
+          // Vertical = a single top-to-bottom column; horizontal = a wrapping
+          // left-to-right grid sized to the number of panes.
+          gridTemplateColumns:
+            layout === 'vertical'
+              ? 'minmax(0, 1fr)'
+              : `repeat(${gridCols}, minmax(300px, 1fr))`,
         }}
       >
         {selectedTimeIndices.map((timeIdx, index) => {

--- a/packages/sterling/src/components/GraphView/MultiTemporalGraph.tsx
+++ b/packages/sterling/src/components/GraphView/MultiTemporalGraph.tsx
@@ -31,8 +31,9 @@ function isOutOfInstances(alloyDataInstance: any): boolean {
 interface MultiTemporalGraphProps {
   datum: DatumParsed<any>;
   cndSpec: string;
-  /** Array of time indices to display */
-  selectedTimeIndices: number[];
+  /** State slots to display. `null` is a sliding-window placeholder (a missing
+   *  before/after neighbour) and renders as an empty "no state" pane. */
+  selectedTimeIndices: (number | null)[];
   /** Total number of time steps in the trace */
   traceLength: number;
   /** Sequence policy name from CND spec */
@@ -378,14 +379,12 @@ const SingleTemporalPane = (props: SingleTemporalPaneProps) => {
       {/* The "State N of M" label is injected into the graph's own toolbar
           (see loadGraph) instead of a separate header strip, to save space. */}
 
-      {/* Graph container */}
+      {/* Graph container — fills the pane; a generous min-height gives the graph
+          room without the over-tall panes that break its layout. */}
       <div
         ref={graphContainerRef}
         className="flex-1"
-        style={{
-          minHeight: '250px',
-          background: 'var(--ccd-surface)'
-        }}
+        style={{ minHeight: '320px', background: 'var(--ccd-surface)' }}
       />
 
       {/* Loading overlay */}
@@ -510,23 +509,52 @@ const MultiTemporalGraph = (props: MultiTemporalGraphProps) => {
     );
   }
 
+  // Window mode (anchor set) shows a fixed before/current/after strip, so put
+  // its slots in a single row; compare mode uses the count-based heuristic.
+  const isWindow = anchorTimeIndex !== undefined;
+  const columns = isWindow ? selectedTimeIndices.length : gridCols;
+
   return (
     <div className="absolute inset-0 overflow-auto bg-surface-sunken p-3">
       {/* No header here — each pane already labels its own "State N of M", so a
           "Temporal Comparison / Showing N of M" banner is redundant and just
           eats vertical space. */}
       <div
-        className="grid gap-4"
+        className="grid min-h-full gap-3"
         style={{
-          // Vertical = a single top-to-bottom column; horizontal = a wrapping
-          // left-to-right grid sized to the number of panes.
+          // Vertical = a single top-to-bottom column; horizontal = a row sized
+          // to the panes. Rows are content-height (each pane sets a generous
+          // min-height); we deliberately do NOT stretch to fill the stage — very
+          // tall panes break the graph's layout/morph (content lands off-screen).
+          // The window's single row is centred so the leftover height reads as
+          // intentional rather than a gap below.
           gridTemplateColumns:
             layout === 'vertical'
               ? 'minmax(0, 1fr)'
-              : `repeat(${gridCols}, minmax(300px, 1fr))`,
+              : `repeat(${columns}, minmax(260px, 1fr))`,
+          gridAutoRows: 'minmax(340px, auto)',
+          alignContent: isWindow ? 'center' : 'start'
         }}
       >
         {selectedTimeIndices.map((timeIdx, index) => {
+          // A null slot is a sliding-window placeholder for a missing neighbour.
+          if (timeIdx === null) {
+            return (
+              <div
+                key={`placeholder-${index}`}
+                className="flex flex-col items-center justify-center gap-1 rounded-lg border border-dashed border-rule bg-surface-sunken text-ink-faint"
+              >
+                <span className="text-sm font-medium">
+                  {index === 0 ? 'No previous state' : 'No next state'}
+                </span>
+                <span className="text-xs">
+                  {index === 0
+                    ? 'State 0 is the start of the trace'
+                    : 'this is the end of the trace'}
+                </span>
+              </div>
+            );
+          }
           const isAnchor = continuityActive && timeIdx === anchorTimeIndex;
           const isFollower = continuityActive && !isAnchor;
           return (

--- a/packages/sterling/src/components/Minimap/Minimap.tsx
+++ b/packages/sterling/src/components/Minimap/Minimap.tsx
@@ -10,10 +10,16 @@ export interface MinimapProps {
   length: number;
   // the loopback index, if one exists
   loopBack?: number;
+  // the set of indices to highlight as "shown" (current, window, or compare
+  // set). Defaults to just the current index when omitted.
+  selectedIndices?: number[];
   // a function that returns the label to display given the current index
   label: (index: number) => string;
-  // a callback to call when the index is changed by the user
+  // a callback to call when the index is changed via the nav controls
   onChange: (index: number) => void;
+  // a callback to call when the user clicks a state circle. Falls back to
+  // onChange when omitted; compare mode uses this to toggle set membership.
+  onNodeClick?: (index: number) => void;
   // a callback to call when the user clicks the collapse button
   onToggleCollapse: () => void;
 }
@@ -21,7 +27,7 @@ export interface MinimapProps {
 const Minimap = (props: MinimapProps) => {
   const { collapsed } = props;
   return (
-    <div className='border rounded mx-2'>
+    <div className='border border-rule rounded mx-2'>
       <MinimapControls {...props} />
       {!collapsed && <MinimapGraph {...props} />}
     </div>

--- a/packages/sterling/src/components/Minimap/MinimapControls.tsx
+++ b/packages/sterling/src/components/Minimap/MinimapControls.tsx
@@ -1,4 +1,5 @@
 import { ButtonGroup, Center, IconButton } from '@chakra-ui/react';
+import { tokens } from '@/sterling-ui';
 import {
   BiArrowToLeft,
   BiArrowToRight,
@@ -22,7 +23,7 @@ const MinimapControls = (props: MinimapProps) => {
   } = props;
   return (
     <div className='flex'>
-      <ButtonGroup width='full' isAttached size='sm'>
+      <ButtonGroup width='full' isAttached size='sm' variant='ghost'>
         <IconButton
           aria-label='First State'
           icon={<BiArrowToLeft />}
@@ -37,7 +38,13 @@ const MinimapControls = (props: MinimapProps) => {
           disabled={current === 0}
           onClick={() => onChange(current - 1)}
         />
-        <Center width='full' px={2} fontSize='xs' bg='gray.100'>
+        <Center
+          width='full'
+          px={2}
+          fontSize='xs'
+          bg={tokens.color.surfaceMuted}
+          color={tokens.color.ink}
+        >
           {label(current)}
         </Center>
         {loopBack !== undefined && current === length - 1 ? (
@@ -49,7 +56,7 @@ const MinimapControls = (props: MinimapProps) => {
           />
         ) : (
           <IconButton
-            aria-label='First State'
+            aria-label='Next State'
             borderRadius={0}
             icon={<BiRightArrowAlt />}
             disabled={current === length - 1}
@@ -57,7 +64,7 @@ const MinimapControls = (props: MinimapProps) => {
           />
         )}
         <IconButton
-          aria-label='Previous State'
+          aria-label='Last State'
           icon={<BiArrowToRight />}
           disabled={current === length - 1}
           onClick={() => onChange(length - 1)}
@@ -67,7 +74,7 @@ const MinimapControls = (props: MinimapProps) => {
           size='sm'
           borderRadius={0}
           borderLeftWidth={1}
-          borderLeftColor='gray.300'
+          borderLeftColor={tokens.color.rule}
           icon={collapsed ? <BiChevronDown /> : <BiChevronUp />}
           onClick={() => onToggleCollapse()}
         />

--- a/packages/sterling/src/components/Minimap/MinimapGraph.tsx
+++ b/packages/sterling/src/components/Minimap/MinimapGraph.tsx
@@ -22,9 +22,9 @@ const MinimapGraph = (props: MinimapProps) => {
     <div className='grid place-items-center overflow-y-auto'>
       <InteractionProvider
         svg={ref.current}
-        onMouseDown={() => console.log('down')}
         onClickNode={(nodeId) => {
-          if (props.onChange) props.onChange(+nodeId);
+          const handler = props.onNodeClick ?? props.onChange;
+          if (handler) handler(+nodeId);
         }}
       >
         <svg
@@ -38,8 +38,8 @@ const MinimapGraph = (props: MinimapProps) => {
             id='minimap'
             graph={graph}
             nodeShapes={nodeShapes(graph)}
-            nodeStyles={nodeStyles(graph, props.current)}
-            nodeLabels={nodeLabels(graph, props.current)}
+            nodeStyles={nodeStyles(graph, props.current, props.selectedIndices)}
+            nodeLabels={nodeLabels(graph, props.current, props.selectedIndices)}
             edgeCurves={edgeCurves(graph)}
             edgeStyles={edgeStyles(graph)}
           />

--- a/packages/sterling/src/components/Minimap/graph.ts
+++ b/packages/sterling/src/components/Minimap/graph.ts
@@ -84,18 +84,28 @@ function edgeStyles(graph: Graph): Record<string, CSSProperties> {
   return edgeStyles;
 }
 
-function nodeLabels(graph: Graph, current: number): Record<string, LabelDef[]> {
+function nodeLabels(
+  graph: Graph,
+  current: number,
+  selectedIndices?: number[]
+): Record<string, LabelDef[]> {
+  const selected = new Set((selectedIndices ?? [current]).map(String));
   const nodeLabels: Record<string, LabelDef[]> = {};
   getNodes(graph).forEach((node) => {
-    const active = node.id === `${current}`;
+    const isSelected = selected.has(node.id);
+    const isCurrent = node.id === `${current}`;
     nodeLabels[`${node.id}`] = [
       {
         text: node.id,
         style: {
-          fill: active ? '#ffffff' : 'var(--ccd-minimap-node-stroke)',
+          // Selected circles are filled with the accent, so their label needs
+          // the on-accent colour (themed per light/dark); others use the stroke.
+          fill: isSelected
+            ? 'var(--ccd-minimap-node-active-label)'
+            : 'var(--ccd-minimap-node-stroke)',
           fontFamily: 'monospace',
           fontSize: '10px',
-          fontWeight: active ? 'bold' : 'normal',
+          fontWeight: isCurrent ? 'bold' : 'normal',
           textAnchor: 'middle',
           userSelect: 'none',
           cursor: 'pointer'
@@ -122,15 +132,27 @@ function nodeShapes(graph: Graph): Record<string, ShapeDef> {
 
 function nodeStyles(
   graph: Graph,
-  current: number
+  current: number,
+  selectedIndices?: number[]
 ): Record<string, CSSProperties> {
+  // Every rendered state is "selected" (filled); the current/anchor state also
+  // gets a stronger, thicker ring so it stands out within the selected set
+  // (e.g. the centre of a sliding window).
+  const selected = new Set((selectedIndices ?? [current]).map(String));
   const nodeStyles: Record<string, CSSProperties> = {};
   getNodes(graph).forEach((node) => {
-    const active = node.id === `${current}`;
+    const isSelected = selected.has(node.id);
+    const isCurrent = node.id === `${current}`;
     nodeStyles[node.id] = {
-      stroke: active ? 'var(--ccd-minimap-node-active)' : 'var(--ccd-minimap-node-stroke)',
-      strokeWidth: 1,
-      fill: active ? 'var(--ccd-minimap-node-active)' : 'var(--ccd-minimap-node-fill)',
+      stroke: isCurrent
+        ? 'var(--ccd-minimap-selected-stroke)'
+        : isSelected
+        ? 'var(--ccd-minimap-node-active)'
+        : 'var(--ccd-minimap-node-stroke)',
+      strokeWidth: isCurrent ? 2.5 : 1,
+      fill: isSelected
+        ? 'var(--ccd-minimap-node-active)'
+        : 'var(--ccd-minimap-node-fill)',
       cursor: 'pointer'
     };
   });

--- a/packages/sterling/src/state/graphs/graphs.ts
+++ b/packages/sterling/src/state/graphs/graphs.ts
@@ -15,6 +15,13 @@ import type { CndProjection, SequencePolicyName } from '../../utils/cndPreParser
  */
 export type PresentationMode = 'single' | 'window' | 'compare';
 
+/**
+ * How side-by-side state panes flow in window/compare mode:
+ * - 'horizontal' — left-to-right (a row, wrapping into a grid).
+ * - 'vertical'   — top-to-bottom (a single column).
+ */
+export type ComparisonLayout = 'horizontal' | 'vertical';
+
 export interface GraphsState {
   layoutsByDatumId: Record<
     string,
@@ -67,6 +74,9 @@ export interface GraphsState {
    * which Time-panel controls are shown.
    */
   presentationModeByDatumId: Record<string, PresentationMode>;
+
+  /** Flow direction for side-by-side state panes. Defaults to 'horizontal'. */
+  comparisonLayoutByDatumId: Record<string, ComparisonLayout>;
 
   /**
    * CND-derived projection configurations by generator name.
@@ -129,6 +139,7 @@ export function newGraphsState(): GraphsState {
     selectedProjectionsByGeneratorName: {},
     selectedTimeIndicesByDatumId: {},
     presentationModeByDatumId: {},
+    comparisonLayoutByDatumId: {},
     projectionConfigByGeneratorName: {},
     sequencePolicyByGeneratorName: {}
   };

--- a/packages/sterling/src/state/graphs/graphs.ts
+++ b/packages/sterling/src/state/graphs/graphs.ts
@@ -6,6 +6,15 @@ import { WritableDraft } from 'immer/dist/types/types-external';
 import { Matrix } from 'transformation-matrix';
 import type { CndProjection, SequencePolicyName } from '../../utils/cndPreParser';
 
+/**
+ * How the Time drawer presents trace states:
+ * - 'single'  — one state at a time (scrub the timeline).
+ * - 'window'  — the state before, the current state, and the state after,
+ *               shown side-by-side (a sliding window over the trace).
+ * - 'compare' — an arbitrary user-chosen set of states, shown side-by-side.
+ */
+export type PresentationMode = 'single' | 'window' | 'compare';
+
 export interface GraphsState {
   layoutsByDatumId: Record<
     string,
@@ -51,6 +60,13 @@ export interface GraphsState {
    * When multiple indices are selected, multiple graphs are shown side-by-side.
    */
   selectedTimeIndicesByDatumId: Record<string, number[]>;
+
+  /**
+   * How the Time drawer presents states for each datum. Defaults to 'single'
+   * (see selectPresentationMode). Drives which time indices are rendered and
+   * which Time-panel controls are shown.
+   */
+  presentationModeByDatumId: Record<string, PresentationMode>;
 
   /**
    * CND-derived projection configurations by generator name.
@@ -112,6 +128,7 @@ export function newGraphsState(): GraphsState {
     cndSpecByGeneratorName: {},
     selectedProjectionsByGeneratorName: {},
     selectedTimeIndicesByDatumId: {},
+    presentationModeByDatumId: {},
     projectionConfigByGeneratorName: {},
     sequencePolicyByGeneratorName: {}
   };

--- a/packages/sterling/src/state/graphs/graphsExtraReducers.ts
+++ b/packages/sterling/src/state/graphs/graphsExtraReducers.ts
@@ -51,8 +51,9 @@ function dataReceived(
       // Choose the first index as the first instance to display
       state.timeByDatumId[datumId] = 0;
 
-      // Default new data to the single-state presentation.
+      // Default new data to the single-state presentation, horizontal panes.
       state.presentationModeByDatumId[datumId] = 'single';
+      state.comparisonLayoutByDatumId[datumId] = 'horizontal';
 
       // If a CnD spec is present in the datum AND we don't already have one for this generator,
       // load it into the state. Otherwise, use the default directive to hide disconnected built-ins.
@@ -86,6 +87,7 @@ function dataReceived(
       delete state.matricesByDatumId[datumId];
       delete state.timeByDatumId[datumId];
       delete state.presentationModeByDatumId[datumId];
+      delete state.comparisonLayoutByDatumId[datumId];
       delete state.hiddenByDatumId[datumId];
     });
   }

--- a/packages/sterling/src/state/graphs/graphsExtraReducers.ts
+++ b/packages/sterling/src/state/graphs/graphsExtraReducers.ts
@@ -51,6 +51,9 @@ function dataReceived(
       // Choose the first index as the first instance to display
       state.timeByDatumId[datumId] = 0;
 
+      // Default new data to the single-state presentation.
+      state.presentationModeByDatumId[datumId] = 'single';
+
       // If a CnD spec is present in the datum AND we don't already have one for this generator,
       // load it into the state. Otherwise, use the default directive to hide disconnected built-ins.
       // Using generator name allows the layout to persist across instances.
@@ -82,6 +85,7 @@ function dataReceived(
       delete state.layoutsByDatumId[datumId];
       delete state.matricesByDatumId[datumId];
       delete state.timeByDatumId[datumId];
+      delete state.presentationModeByDatumId[datumId];
       delete state.hiddenByDatumId[datumId];
     });
   }

--- a/packages/sterling/src/state/graphs/graphsReducers.ts
+++ b/packages/sterling/src/state/graphs/graphsReducers.ts
@@ -19,7 +19,7 @@ import { produce, castDraft } from 'immer';
 import { WritableDraft } from 'immer/dist/types/types-external';
 import { forEach, remove, set, unset } from 'lodash-es';
 import { Matrix } from 'transformation-matrix';
-import { generateLayoutId, GraphsState, PresentationMode } from './graphs';
+import { ComparisonLayout, generateLayoutId, GraphsState, PresentationMode } from './graphs';
 import { DEFAULT_LAYOUT_SETTINGS } from './graphsDefaults';
 import { LiteralUnion } from 'prettier';
 import { parseCndFile } from '../../utils/cndPreParser';
@@ -803,6 +803,18 @@ function presentationModeSet(
 }
 
 /**
+ * Set the flow direction ('horizontal' | 'vertical') for side-by-side state
+ * panes in window/compare mode.
+ */
+function comparisonLayoutSet(
+  state: DraftState,
+  action: PayloadAction<{ datum: DatumParsed<any>; layout: ComparisonLayout }>
+) {
+  const { datum, layout } = action.payload;
+  state.comparisonLayoutByDatumId[datum.id] = layout;
+}
+
+/**
  * Set the CnD spec for a generator (by generator name, so it persists across instances).
  * Also parses projections and sequence policy from the CND spec.
  */
@@ -943,6 +955,7 @@ export default {
   nodeLabelPropSet,
   nodeLabelStyleRemoved,
   nodeLabelStyleSet,
+  comparisonLayoutSet,
   nodesOffset,
   presentationModeSet,
   projectionAdded,

--- a/packages/sterling/src/state/graphs/graphsReducers.ts
+++ b/packages/sterling/src/state/graphs/graphsReducers.ts
@@ -19,7 +19,7 @@ import { produce, castDraft } from 'immer';
 import { WritableDraft } from 'immer/dist/types/types-external';
 import { forEach, remove, set, unset } from 'lodash-es';
 import { Matrix } from 'transformation-matrix';
-import { generateLayoutId, GraphsState } from './graphs';
+import { generateLayoutId, GraphsState, PresentationMode } from './graphs';
 import { DEFAULT_LAYOUT_SETTINGS } from './graphsDefaults';
 import { LiteralUnion } from 'prettier';
 import { parseCndFile } from '../../utils/cndPreParser';
@@ -791,6 +791,18 @@ function timeIndexSet(
 }
 
 /**
+ * Set how the Time drawer presents states for a datum
+ * ('single' | 'window' | 'compare').
+ */
+function presentationModeSet(
+  state: DraftState,
+  action: PayloadAction<{ datum: DatumParsed<any>; mode: PresentationMode }>
+) {
+  const { datum, mode } = action.payload;
+  state.presentationModeByDatumId[datum.id] = mode;
+}
+
+/**
  * Set the CnD spec for a generator (by generator name, so it persists across instances).
  * Also parses projections and sequence policy from the CND spec.
  */
@@ -932,6 +944,7 @@ export default {
   nodeLabelStyleRemoved,
   nodeLabelStyleSet,
   nodesOffset,
+  presentationModeSet,
   projectionAdded,
   projectionAtomToggled,
   projectionOrderingSet,

--- a/packages/sterling/src/state/graphs/graphsSelectors.ts
+++ b/packages/sterling/src/state/graphs/graphsSelectors.ts
@@ -2,7 +2,7 @@ import { GraphLayout } from '@/alloy-graph';
 import { DatumParsed } from '@/sterling-connection';
 import { Projection, SterlingTheme } from '@/sterling-theme';
 import { Matrix } from 'transformation-matrix';
-import { generateLayoutId, GraphsState } from './graphs';
+import { generateLayoutId, GraphsState, PresentationMode } from './graphs';
 import type { CndProjection, SequencePolicyName } from '../../utils/cndPreParser';
 
 /**
@@ -112,6 +112,17 @@ function selectSelectedTimeIndices(
 }
 
 /**
+ * Select how the Time drawer presents states for a datum.
+ * Defaults to 'single' when nothing has been chosen yet.
+ */
+function selectPresentationMode(
+  state: GraphsState,
+  datum: DatumParsed<any>
+): PresentationMode {
+  return state.presentationModeByDatumId[datum.id] ?? 'single';
+}
+
+/**
  * Select the CND-derived projection configuration for a datum.
  * These are the projection directives parsed from the top-level `projections`
  * block of the CND spec.
@@ -140,6 +151,7 @@ function selectSequencePolicyName(
 export default {
   selectGraphLayout,
   selectHiddenRelations,
+  selectPresentationMode,
   selectProjections,
   selectProjectionConfig,
   selectSelectedProjections,

--- a/packages/sterling/src/state/graphs/graphsSelectors.ts
+++ b/packages/sterling/src/state/graphs/graphsSelectors.ts
@@ -2,7 +2,7 @@ import { GraphLayout } from '@/alloy-graph';
 import { DatumParsed } from '@/sterling-connection';
 import { Projection, SterlingTheme } from '@/sterling-theme';
 import { Matrix } from 'transformation-matrix';
-import { generateLayoutId, GraphsState, PresentationMode } from './graphs';
+import { ComparisonLayout, generateLayoutId, GraphsState, PresentationMode } from './graphs';
 import type { CndProjection, SequencePolicyName } from '../../utils/cndPreParser';
 
 /**
@@ -123,6 +123,17 @@ function selectPresentationMode(
 }
 
 /**
+ * Select the flow direction for side-by-side state panes. Defaults to
+ * 'horizontal'.
+ */
+function selectComparisonLayout(
+  state: GraphsState,
+  datum: DatumParsed<any>
+): ComparisonLayout {
+  return state.comparisonLayoutByDatumId[datum.id] ?? 'horizontal';
+}
+
+/**
  * Select the CND-derived projection configuration for a datum.
  * These are the projection directives parsed from the top-level `projections`
  * block of the CND spec.
@@ -151,6 +162,7 @@ function selectSequencePolicyName(
 export default {
   selectGraphLayout,
   selectHiddenRelations,
+  selectComparisonLayout,
   selectPresentationMode,
   selectProjections,
   selectProjectionConfig,

--- a/packages/sterling/src/state/graphs/graphsSlice.ts
+++ b/packages/sterling/src/state/graphs/graphsSlice.ts
@@ -32,6 +32,7 @@ export const {
   nodeLabelStyleSet,
   nodeLabelPropRemoved,
   nodeLabelPropSet,
+  comparisonLayoutSet,
   nodesOffset,
   presentationModeSet,
   projectionAdded,

--- a/packages/sterling/src/state/graphs/graphsSlice.ts
+++ b/packages/sterling/src/state/graphs/graphsSlice.ts
@@ -33,6 +33,7 @@ export const {
   nodeLabelPropRemoved,
   nodeLabelPropSet,
   nodesOffset,
+  presentationModeSet,
   projectionAdded,
   projectionAtomToggled,
   projectionOrderingSet,

--- a/packages/sterling/src/state/selectors.ts
+++ b/packages/sterling/src/state/selectors.ts
@@ -702,35 +702,16 @@ export function selectComparisonLayout(
 }
 
 /**
- * Build the sliding-window indices [before, current, after] around `current`.
- * At the trace ends there is no neighbour: if the trace loops (loopBack is
- * defined) we wrap — the state before index 0 is the last state, and the state
- * after the last state is the loop-back target — otherwise we clamp (drop the
- * missing neighbour, leaving 2 states at the edges).
+ * Build the sliding-window slots [before, current, after] around `current`.
+ * A slot is `null` when the neighbour doesn't exist — before state 0, or after
+ * the last state — which the renderer shows as an empty "no state" placeholder
+ * (so state 0 reads as [—, 0, 1], keeping the current state in the middle).
  */
-function windowIndices(
-  current: number,
-  length: number,
-  loopBack: number | undefined
-): number[] {
-  if (length <= 1) return [0];
-  const before =
-    current - 1 >= 0
-      ? current - 1
-      : loopBack !== undefined
-      ? length - 1
-      : undefined;
-  const after =
-    current + 1 < length
-      ? current + 1
-      : loopBack !== undefined
-      ? loopBack
-      : undefined;
-  const raw = [before, current, after].filter(
-    (i): i is number => i !== undefined
-  );
-  // Dedup while preserving order (tiny/looping traces can repeat an index).
-  return Array.from(new Set(raw));
+function windowSlots(current: number, length: number): (number | null)[] {
+  if (length <= 1) return [current];
+  const before = current - 1 >= 0 ? current - 1 : null;
+  const after = current + 1 < length ? current + 1 : null;
+  return [before, current, after];
 }
 
 /**
@@ -739,7 +720,8 @@ function windowIndices(
  *   single  -> [current]
  *   window  -> [before, current, after]   (wraps on looping traces, else clamps)
  *   compare -> the user's stored set       (falls back to [current] when empty)
- * The side-by-side renderer keys purely off this set, so all three modes share
+ * A slot may be `null` (a sliding-window placeholder for a missing neighbour).
+ * The side-by-side renderer keys purely off this list, so all three modes share
  * one render path. Memoized (createSelector) so single/window return a stable
  * array reference instead of re-rendering consumers on every dispatch.
  */
@@ -752,12 +734,10 @@ export const selectEffectiveTimeIndices = createSelector(
     (state: SterlingState, datum: DatumParsed<any>) =>
       selectTraceLength(state, datum),
     (state: SterlingState, datum: DatumParsed<any>) =>
-      selectLoopbackIndex(state, datum),
-    (state: SterlingState, datum: DatumParsed<any>) =>
       selectSelectedTimeIndices(state, datum)
   ],
-  (mode, current, length, loopBack, compareSet): number[] => {
-    if (mode === 'window') return windowIndices(current, length, loopBack);
+  (mode, current, length, compareSet): (number | null)[] => {
+    if (mode === 'window') return windowSlots(current, length);
     if (mode === 'compare')
       return compareSet.length > 0 ? compareSet : [current];
     return [current];

--- a/packages/sterling/src/state/selectors.ts
+++ b/packages/sterling/src/state/selectors.ts
@@ -29,7 +29,7 @@ import { Matrix } from 'transformation-matrix';
 import dataSelectors from './data/dataSelectors';
 import { Expression } from './evaluator/evaluator';
 import evaluatorSelectors from './evaluator/evaluatorSelectors';
-import { RelationStyle, TypeStyle } from './graphs/graphs';
+import { PresentationMode, RelationStyle, TypeStyle } from './graphs/graphs';
 import graphsSelectors from './graphs/graphsSelectors';
 import { LogItem } from './log/log';
 import logSelectors from './log/logSelectors';
@@ -678,6 +678,80 @@ export function selectSelectedTimeIndices(
 ): number[] {
   return graphsSelectors.selectSelectedTimeIndices(state.graphs, datum);
 }
+
+/**
+ * Select how the Time drawer presents states for a datum
+ * ('single' | 'window' | 'compare').
+ */
+export function selectPresentationMode(
+  state: SterlingState,
+  datum: DatumParsed<any>
+): PresentationMode {
+  return graphsSelectors.selectPresentationMode(state.graphs, datum);
+}
+
+/**
+ * Build the sliding-window indices [before, current, after] around `current`.
+ * At the trace ends there is no neighbour: if the trace loops (loopBack is
+ * defined) we wrap — the state before index 0 is the last state, and the state
+ * after the last state is the loop-back target — otherwise we clamp (drop the
+ * missing neighbour, leaving 2 states at the edges).
+ */
+function windowIndices(
+  current: number,
+  length: number,
+  loopBack: number | undefined
+): number[] {
+  if (length <= 1) return [0];
+  const before =
+    current - 1 >= 0
+      ? current - 1
+      : loopBack !== undefined
+      ? length - 1
+      : undefined;
+  const after =
+    current + 1 < length
+      ? current + 1
+      : loopBack !== undefined
+      ? loopBack
+      : undefined;
+  const raw = [before, current, after].filter(
+    (i): i is number => i !== undefined
+  );
+  // Dedup while preserving order (tiny/looping traces can repeat an index).
+  return Array.from(new Set(raw));
+}
+
+/**
+ * Select the time indices actually rendered on the stage, derived from the
+ * datum's presentation mode:
+ *   single  -> [current]
+ *   window  -> [before, current, after]   (wraps on looping traces, else clamps)
+ *   compare -> the user's stored set       (falls back to [current] when empty)
+ * The side-by-side renderer keys purely off this set, so all three modes share
+ * one render path. Memoized (createSelector) so single/window return a stable
+ * array reference instead of re-rendering consumers on every dispatch.
+ */
+export const selectEffectiveTimeIndices = createSelector(
+  [
+    (state: SterlingState, datum: DatumParsed<any>) =>
+      selectPresentationMode(state, datum),
+    (state: SterlingState, datum: DatumParsed<any>) =>
+      selectTimeIndex(state, datum),
+    (state: SterlingState, datum: DatumParsed<any>) =>
+      selectTraceLength(state, datum),
+    (state: SterlingState, datum: DatumParsed<any>) =>
+      selectLoopbackIndex(state, datum),
+    (state: SterlingState, datum: DatumParsed<any>) =>
+      selectSelectedTimeIndices(state, datum)
+  ],
+  (mode, current, length, loopBack, compareSet): number[] => {
+    if (mode === 'window') return windowIndices(current, length, loopBack);
+    if (mode === 'compare')
+      return compareSet.length > 0 ? compareSet : [current];
+    return [current];
+  }
+);
 
 /**
  * Select the CND-derived projection configuration for a datum.

--- a/packages/sterling/src/state/selectors.ts
+++ b/packages/sterling/src/state/selectors.ts
@@ -29,7 +29,7 @@ import { Matrix } from 'transformation-matrix';
 import dataSelectors from './data/dataSelectors';
 import { Expression } from './evaluator/evaluator';
 import evaluatorSelectors from './evaluator/evaluatorSelectors';
-import { PresentationMode, RelationStyle, TypeStyle } from './graphs/graphs';
+import { ComparisonLayout, PresentationMode, RelationStyle, TypeStyle } from './graphs/graphs';
 import graphsSelectors from './graphs/graphsSelectors';
 import { LogItem } from './log/log';
 import logSelectors from './log/logSelectors';
@@ -688,6 +688,17 @@ export function selectPresentationMode(
   datum: DatumParsed<any>
 ): PresentationMode {
   return graphsSelectors.selectPresentationMode(state.graphs, datum);
+}
+
+/**
+ * Select the flow direction ('horizontal' | 'vertical') for side-by-side state
+ * panes in window/compare mode.
+ */
+export function selectComparisonLayout(
+  state: SterlingState,
+  datum: DatumParsed<any>
+): ComparisonLayout {
+  return graphsSelectors.selectComparisonLayout(state.graphs, datum);
 }
 
 /**


### PR DESCRIPTION
Reworks the Time drawer into three state-presentation modes, makes the temporal policy apply to multi-state views, and tightens the whole panel's use of space.

## Presentation modes
One per-datum **presentation mode** (`single | window | compare`) drives both which states render and which controls show:

- **Single State** — one state; scrub the timeline.
- **Sliding Window** — a fixed `[before, current, after]` strip. At a trace end the missing neighbour renders an empty **"No previous/next state"** placeholder, so state 0 reads as `[—, 0, 1]` with the current state centred.
- **Compare States** — an arbitrary set, picked by **toggling circles on the one shared timeline** (the old duplicate numbered-button picker is gone). "First & Last / All" helpers show only here.

The side-by-side renderer keys purely off the selected-index list, so all three modes share one render path: a memoized `selectEffectiveTimeIndices` derives the list (incl. window placeholders) from the mode.

## Temporal policy in multi-state views
`MultiTemporalGraph` previously ignored the sequence policy entirely. In window mode the current state now lays out fresh and the before/after panes morph toward it via `getSequencePolicy()` + `renderLayout({ policy, currInstance, prevInstance, priorPositions })`, mirroring single-state continuity, so persistent nodes stay put across the window. (Verified: toggling the policy shifts a follower pane's layout ~170px.)

## Compare-selection fix
Clicking a timeline circle in Compare did nothing because React StrictMode double-invokes the graph's interaction reducer → the non-idempotent toggle fired twice and cancelled itself out. Switched to computing the next set and dispatching an idempotent `selectedTimeIndicesSet`, so double-invocation is a no-op.

## Viewport / space
- Multi-pane panes were a cramped 250px; forcing them to fill the stage made them tall-and-narrow and broke the graph layout (blank panes). Panes are now content-height with a generous min-height, and the single window row is vertically centred.
- Per-pane **"State N of M"** moved into the graph's own toolbar; the redundant "Temporal Comparison / Showing N of M" banner removed.
- **Compact Time controls** (POLICY / SHOW), a horizontal/vertical **pane-flow toggle**, the instance **ID moved into the top nav bar**, and the drawer toggle relabelled **"Control Panel"**.
- State numbers are **0-based**, matching the timeline circles and the trace's indexing (initial state = State 0).
- Fixed the minimap control bar's dark-mode theming (hardcoded `gray.100`/`gray.300` → token layer; `#ffffff` active label → per-theme var; removed a stray `console.log`).

## Verification
Exercised against the mock 12-state `rc` trace, light & dark: all three modes, the window state-0 placeholder edge, Compare circle-toggle + First&Last/All, and policy on/off. No new console errors (only pre-existing React 18 / Chakra `defaultProps` warnings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)