### PR TITLE
CI: bump GitHub Actions to Node 24 majors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,8 +9,8 @@ jobs:
   build-test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
         with:
           node-version: 18
           cache: yarn

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -19,8 +19,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
         with:
           node-version: 20
           cache: yarn

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,9 +18,9 @@ jobs:
   build-and-release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: 18
           cache: yarn
@@ -87,7 +87,7 @@ jobs:
           fi
       
       - name: Create Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ steps.tag_name.outputs.tag }}
           name: Release ${{ steps.tag_name.outputs.tag }}

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sterling-layout",
   "description": "Cope and Drag (CnD): a fork of the Sterling visualizer that encodes spatial layout.",
-  "version": "4.0.13",
+  "version": "4.0.14",
   "main": "index.js",
   "author": "Siddhartha Prasad",
   "license": "MIT",


### PR DESCRIPTION
The v4.0.13 release run flagged `actions/checkout@v4`, `actions/setup-node@v4`, and `softprops/action-gh-release@v1` as running on the deprecated **Node 20** runtime (GitHub forces Node 24 starting 2026-06-16, removes Node 20 on 2026-09-16).

Bumps them to their Node 24 majors across all three workflows:
- `actions/checkout@v4` → `@v5` (ci, release, deploy-pages)
- `actions/setup-node@v4` → `@v5` (ci, release, deploy-pages)
- `softprops/action-gh-release@v1` → `@v2` (release)

The GitHub Pages actions (`configure-pages@v5`, `upload-pages-artifact@v3`, `deploy-pages@v4`) are already on their latest majors, so they're left as-is.

No input/behavior changes — same `node-version`, `cache`, and release inputs. CI on this PR exercises the checkout/setup-node bump directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)