### PR TITLE
Remove graph's built-in Mode (theme) dropdown from toolbar

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sterling-layout",
   "description": "Cope and Drag (CnD): a fork of the Sterling visualizer that encodes spatial layout.",
-  "version": "4.0.14",
+  "version": "4.0.15",
   "main": "index.js",
   "author": "Siddhartha Prasad",
   "license": "MIT",

--- a/packages/sterling/src/components/GraphView/MultiProjectionGraph.tsx
+++ b/packages/sterling/src/components/GraphView/MultiProjectionGraph.tsx
@@ -2,7 +2,7 @@ import { DatumParsed } from '@/sterling-connection';
 import { useCallback, useEffect, useLayoutEffect, useRef, useState, useMemo } from 'react';
 import type { LayoutState, TransformInfo, NodePositionHint } from './SpyTialGraph';
 import { parseCndFile, CndProjection, SequencePolicyName } from '../../utils/cndPreParser';
-import { getSpytialCore, hasSpytialCore } from '../../utils/spytialCore';
+import { getSpytialCore, hasSpytialCore, removeGraphThemeControl } from '../../utils/spytialCore';
 import { useSterlingSelector } from '../../state/hooks';
 import { selectColorMode } from '../../state/selectors';
 
@@ -217,6 +217,9 @@ const SingleProjectionPane = (props: SingleProjectionPaneProps) => {
     graphElement.setAttribute('layoutFormat', 'default');
     graphElement.setAttribute('aria-label', `Graph visualization for ${atomLabel}`);
     graphElement.setAttribute('theme', colorModeRef.current);
+    // CopeAndDrag owns theming globally, so drop the graph's built-in per-graph
+    // Mode (theme) dropdown from its toolbar.
+    removeGraphThemeControl(graphElement);
     graphElement.style.cssText = `
       width: 100%;
       height: 100%;

--- a/packages/sterling/src/components/GraphView/MultiTemporalGraph.tsx
+++ b/packages/sterling/src/components/GraphView/MultiTemporalGraph.tsx
@@ -1,7 +1,7 @@
 import { DatumParsed } from '@/sterling-connection';
 import { useCallback, useEffect, useLayoutEffect, useRef, useState, useMemo } from 'react';
 import { parseCndFile, SequencePolicyName } from '../../utils/cndPreParser';
-import { getSpytialCore, hasSpytialCore } from '../../utils/spytialCore';
+import { getSpytialCore, hasSpytialCore, removeGraphThemeControl } from '../../utils/spytialCore';
 import { useSterlingSelector } from '../../state/hooks';
 import { selectColorMode } from '../../state/selectors';
 import type { LayoutState } from './SpyTialGraph';
@@ -326,6 +326,9 @@ const SingleTemporalPane = (props: SingleTemporalPaneProps) => {
     graphElement.setAttribute('layoutFormat', 'default');
     graphElement.setAttribute('aria-label', `Graph visualization for state ${timeIndex}`);
     graphElement.setAttribute('theme', colorModeRef.current);
+    // CopeAndDrag owns theming globally, so drop the graph's built-in per-graph
+    // Mode (theme) dropdown from its toolbar.
+    removeGraphThemeControl(graphElement);
     graphElement.style.cssText = `
       width: 100%;
       height: 100%;

--- a/packages/sterling/src/components/GraphView/SpyTialGraph.tsx
+++ b/packages/sterling/src/components/GraphView/SpyTialGraph.tsx
@@ -1,7 +1,7 @@
 import { DatumParsed } from '@/sterling-connection';
 import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
 import { parseCndFile, type CndProjection, type SequencePolicyName } from '../../utils/cndPreParser';
-import { getSpytialCore, hasSpytialCore } from '../../utils/spytialCore';
+import { getSpytialCore, hasSpytialCore, removeGraphThemeControl } from '../../utils/spytialCore';
 import { useSterlingDispatch, useSterlingSelector } from '../../state/hooks';
 import { selectColorMode } from '../../state/selectors';
 import { colorModeSet } from '../../state/ui/uiSlice';
@@ -457,6 +457,9 @@ const SpyTialGraph = (props: SpyTialGraphProps) => {
     // Start the graph on the app's current theme (declarative; applied by the
     // element's attributeChangedCallback).
     graphElement.setAttribute('theme', colorModeRef.current);
+    // CopeAndDrag owns theming globally, so drop the graph's built-in per-graph
+    // Mode (theme) dropdown from its toolbar.
+    removeGraphThemeControl(graphElement);
     graphElement.style.cssText = `
       width: 100%;
       height: 100%;

--- a/packages/sterling/src/utils/spytialCore.ts
+++ b/packages/sterling/src/utils/spytialCore.ts
@@ -120,6 +120,24 @@ export function hasSpytialCore(): boolean {
 }
 
 /**
+ * Remove the graph's built-in "Mode" theme dropdown from its toolbar.
+ *
+ * The webcola-cnd-graph element (spytial-core) ships a `Mode:` <select> in its
+ * shadow-DOM toolbar (the `#mode-control` group) that lets the user switch the
+ * graph's color theme per-instance. CopeAndDrag owns theming globally — the app
+ * color mode drives every graph via setTheme() — so the per-graph control is
+ * redundant and can desync the app chrome from the graph. We drop it here.
+ *
+ * The toolbar is built once, synchronously, in the element's constructor
+ * (initializeDOM sets shadowRoot.innerHTML and is never re-run on relayout), so
+ * `#mode-control` is present immediately after createElement and is safe to
+ * remove at that point. No-op if the element hasn't been upgraded yet.
+ */
+export function removeGraphThemeControl(graphElement: HTMLElement): void {
+  graphElement.shadowRoot?.querySelector('#mode-control')?.remove();
+}
+
+/**
  * Ensure the SpyTial Bootstrap stylesheet is present in <head>.
  *
  * SpyTial's mounted React components — the CnD layout editor and the error


### PR DESCRIPTION
## What

The `webcola-cnd-graph` element (spytial-core) ships a `Mode:` theme dropdown in its shadow-DOM toolbar that switches the graph's color theme per-instance. CopeAndDrag owns theming globally — the app color mode drives every graph via `setTheme()` — so the per-graph control is redundant and can desync the app chrome from the graph. This removes it.

## How

- Add `removeGraphThemeControl(graphElement)` to `spytialCore.ts`, which drops the `#mode-control` group from the element's shadow DOM.
- Call it at all three graph mount sites: `SpyTialGraph`, `MultiProjectionGraph`, `MultiTemporalGraph`.

The toolbar HTML is built once, synchronously, in the element's constructor (`initializeDOM` sets `shadowRoot.innerHTML` and is never re-run on relayout), so `#mode-control` is present immediately after `createElement` and is safe to remove at that point.

Version bumped 4.0.14 → 4.0.15.

## Verification

Ran the mock app, rendered a graph, inspected the toolbar's shadow DOM:

- `#mode-control` / `#theme-mode`: **removed**
- Remaining toolbar groups: `zoom-controls`, `routing-control`, `screenshot-control` — **intact**

No new console errors. The app's own theme toggle is untouched.

## Note

`SpyTialGraph`'s `theme-changed` listener (which synced the graph dropdown back to the app) is now effectively dead code, since the dropdown was its only emitter. Left in place as it's harmless and defensive; can be removed in a follow-up if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)