### PR TITLE
Help modal: link to Cope and Drag documentation

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -20,6 +20,15 @@
       "port": 8081
     },
     {
+      "name": "sterling-mock-nvm",
+      "runtimeExecutable": "bash",
+      "runtimeArgs": [
+        "-c",
+        "source ~/.nvm/nvm.sh && nvm use 22 >/dev/null && npx webpack serve --mode=development --env provider=mock"
+      ],
+      "port": 8081
+    },
+    {
       "name": "docs",
       "runtimeExecutable": "bash",
       "runtimeArgs": [

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sterling-layout",
   "description": "Cope and Drag (CnD): a fork of the Sterling visualizer that encodes spatial layout.",
-  "version": "4.0.16",
+  "version": "4.0.17",
   "main": "index.js",
   "author": "Siddhartha Prasad",
   "license": "MIT",

--- a/packages/sterling/src/components/AppStatusBar/HelpModal.tsx
+++ b/packages/sterling/src/components/AppStatusBar/HelpModal.tsx
@@ -1,6 +1,6 @@
-import { Modal, ModalBody, ModalCloseButton, 
-         ModalContent, ModalFooter, ModalHeader, ModalOverlay, Center, 
-         Box,
+import { Modal, ModalBody, ModalCloseButton,
+         ModalContent, ModalFooter, ModalHeader, ModalOverlay, Center,
+         Box, Link,
          Divider} from '@chakra-ui/react';
 import { useSterlingSelector } from 'sterling/src/state/hooks';
 import { selectMainView } from 'sterling/src/state/selectors';
@@ -34,6 +34,7 @@ export function HelpModal({isOpen, onClose}: HelpProps) {
             <Box as="ul" listStyleType="circle">
                 <li>Use the <strong>evaluator</strong> tab to query the value of expressions and constraints.</li>
                 <li>The <strong>explorer</strong> tab lets you pick a run to visualize. Click on any prior instance to reload it in the visualizer.</li>
+                <li>Read the full <Link color="blue.500" fontWeight="semibold" href="https://www.siddharthaprasad.com/copeanddrag/cnd/" isExternal>Cope and Drag documentation</Link> for a complete guide.</li>
             </Box>
             <Divider orientation="horizontal" colorScheme="blackAlpha" />
             {mainView === 'ScriptView' && <ScriptViewHelp/>}


### PR DESCRIPTION
## What

The **Help** button (overflow menu → Help) opened a modal with only static text and no way to reach the docs. This adds a prominent link to the [Cope and Drag documentation](https://www.siddharthaprasad.com/copeanddrag/cnd/) in the modal's intro section.

`packages/sterling/src/components/AppStatusBar/HelpModal.tsx`:
- Import Chakra's `Link`.
- Add a bullet: *"Read the full **Cope and Drag documentation** for a complete guide."* linking to `https://www.siddharthaprasad.com/copeanddrag/cnd/`. Using `isExternal` applies `target="_blank"` + `rel="noopener noreferrer"`, matching the external-link convention used elsewhere in the codebase.

Bumps version `4.0.16` → `4.0.17`.

## Verification

- `tsc --noEmit` passes.
- Ran the mock dev server, opened the Help modal, and confirmed the link renders with the correct `href`, `target="_blank"`, and `rel="noopener noreferrer"`.

## Also included

A `sterling-mock-nvm` entry in `.claude/launch.json` that runs the mock dev server under Node 22 via nvm (the existing `sterling-mock` entry uses whatever Node is on PATH, which fails on the repo's default Node 16). Happy to drop this if you'd prefer to keep the PR purely to the docs link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)